### PR TITLE
Support for writing to an existing buffer

### DIFF
--- a/playground/index-raw.html
+++ b/playground/index-raw.html
@@ -97,9 +97,10 @@ console.log(array.toBase64({ alphabet: 'base64url' }));
 </code></pre>
 
 <h3>Streaming</h3>
-<p>Two additional methods, <code>toPartialBase64</code> and <code>fromPartialBase64</code>, allow encoding and decoding chunks of base64. This requires managing state, which is handled by returning a <code>{ result, extra }</code> pair. The options bag for these methods takes two additional arguments, one which specifies whether more data is expected and one which specifies any extra values returned by a previous call.</p>
+<p>Two additional methods, <code>toPartialBase64</code> and <code>fromPartialBase64</code>, allow encoding and decoding chunks of base64. This requires managing state, which is handled by returning a <code>{ result, extra }</code> pair; the <code>extra</code> argument must be round-tripped by the user to the next call as part of the options bag.</p>
+<p><code>toPartialBase64</code> requires specifing a <code>more</code> parameter, which should be true for all but the final chunk, in order to generate the final characters and any necessary padding.</p>
 <p>These methods are intended for lower-level use and are less convenient to use.</p>
-<p>Streaming versions of the hex APIs are not included since they are straightforward to do manually.</p>
+<p>Streaming versions of the hex APIs are not included at this time. That may change.</p>
 
 <p>Streaming an ArrayBuffer into chunks of base64 strings:</p>
 <pre class="language-js"><code class="language-js">
@@ -116,6 +117,8 @@ for (let offset = 0; offset < buffer.byteLength; offset += chunkSize) {
 }
 ({ result } = extra.toPartialBase64({ more: false }));
 resultChunks.push(result);
+// result chunks are guaranteed to be correct-padded base64 strings
+
 console.log(resultChunks);
 // ['mpmZmZmZ', 'uT+amZmZ', 'mZnJPzMz', 'MzMzM9M/', 'mpmZmZmZ', '', '2T8=']
 </code></pre>
@@ -123,19 +126,17 @@ console.log(resultChunks);
 <p>Streaming base64 strings into Uint8Arrays:</p>
 <pre class="language-js"><code class="language-js">
 let chunks = ['mpmZmZmZuT+am', 'ZmZmZnJPzMz', 'MzMz', 'M9M/mpmZmZmZ', '2T8='];
-// individual chunks are not necessarily correctly-padded base64 strings
+// individual chunks are not required to be correctly-padded base64 strings
 
 let output = new Uint8Array(new ArrayBuffer(0, { maxByteLength: 1024 }));
 let result, extra;
 for (let c of chunks) {
-  ({ result, extra } = Uint8Array.fromPartialBase64(c, { more: true, extra }));
+  ({ result, extra, } = Uint8Array.fromPartialBase64(c, { extra }));
   let offset = output.length;
   let newLength = offset + result.length;
   output.buffer.resize(newLength);
   output.set(result, offset);
 }
-// if padding was optional,
-// you'd need to do a final `fromPartialBase64` call here with `more: false`
 
 console.log(new Float64Array(output.buffer));
 // Float64Array([0.1, 0.2, 0.3, 0.4])
@@ -190,6 +191,76 @@ source
   .pipeThrough(new BufferToStringTransformStream())
   .pipeTo(sink);
 </code></pre>
+
+<h3>Decoding base64 strings to an existing Uint8Array</h3>
+<p><code>fromPartialBase64</code> additionally allows you to write data into to an existing buffer. This is handled by an <code>into</code> argument in the options bag, together with <code>inputOffset</code> and <code>outputOffset</code> arguments, as well as <code>read</code> and <written> return values.</p>
+
+<pre class="language-js"><code class="language-js">
+let input = 'SGVsbG8gV29ybGQ=';
+let buffer = new Uint8Array(4);
+let outputOffset = 0;
+let inputOffset = 0;
+let extra, written, read;
+
+while (inputOffset < input.length) {
+  0, { extra, written, read } = Uint8Array.fromPartialBase64(input, {
+    extra,
+    into: buffer,
+    inputOffset,
+    outputOffset,
+  });
+
+  inputOffset += read;
+  outputOffset += written;
+
+  if (outputOffset === buffer.length) {
+    // output is full; consume it
+    console.log([...buffer]);
+    outputOffset = 0;
+  }
+}
+if (outputOffset > 0) {
+  console.log([...buffer].slice(0, outputOffset));
+}
+</code></pre>
+
+<p>This can be combined with streaming as follows:</p>
+<pre class="language-js"><code class="language-js">
+let chunks = ['VGhpcyB', 'pcyBzb2', '1lIGV4YW1w', 'bGUgZGF0YS4='];
+let output = new Uint8Array(4);
+let outputOffset = 0;
+let extra;
+for (let chunk of chunks) {
+  let written, read;
+  let inputOffset = 0;
+
+  while (inputOffset < chunk.length) {
+    0, { extra, written, read } = Uint8Array.fromPartialBase64(chunk, {
+      extra,
+      into: output,
+      inputOffset,
+      outputOffset,
+    });
+
+    inputOffset += read;
+    outputOffset += written;
+
+    if (outputOffset === output.length) {
+      // output is full; consume it
+      console.log([...output]);
+      outputOffset = 0;
+    }
+  }
+}
+if (outputOffset > 0) {
+  console.log([...output].slice(0, outputOffset));
+}
+</code></pre>
+
+<p>This is guaranteed to fill the provided Uint8Array if enough input is available to do so.</p>
+
+<h3>Decoding hex strings to an existing Uint8Array</h3>
+<p>At the moment there is no facility to do so. We will likely add a <code>fromPartialHex</code> method similar to <code>fromPartialHex</code> which provides this ability.
 
 <footer>
   <p>Thanks for reading! If you got this far, you should try out the proposal in your browser's developer tools on this page, and submit feedback on <a href="https://github.com/tc39/proposal-arraybuffer-base64">GitHub</a>.</p>

--- a/playground/polyfill-core.mjs
+++ b/playground/polyfill-core.mjs
@@ -79,8 +79,7 @@ export function uint8ArrayToBase64(arr, alphabetIdentifier = 'base64', more = fa
 
 // this is extremely inefficient, but easy to reason about
 // actual implementations should use something more efficient except possibly at boundaries
-// TODO not export
-export function decodeOneBase64Character(extraBitCount, extraBits, alphabetMap, char) {
+function decodeOneBase64Character(extraBitCount, extraBits, alphabetMap, char) {
   let val = alphabetMap.get(char);
   switch (extraBitCount) {
     case 0: {
@@ -106,9 +105,8 @@ export function decodeOneBase64Character(extraBitCount, extraBits, alphabetMap, 
 }
 
 
-// TODO not export
 // TODO simplify
-export function countFullBytesInBase64StringIncludingExtraBits(str, extraBitCount) {
+function countFullBytesInBase64StringIncludingExtraBits(str, extraBitCount) {
   if (str === '=' && extraBitCount === 0) {
     // special case arising when a `=` char is the second half of a `==` pair
     return 0;
@@ -207,8 +205,8 @@ export function base64ToUint8Array(str, alphabet, into = null, extraBitCount = 0
     0, { extraBitCount, extraBits } = decodeOneBase64Character(extraBitCount, extraBits, alphabetMap, char);
     ++read;
   }
-  // TODO maybe have `extra` be undefined when extraBitCount is 0
-  return { result: into, read, written, extra: { count: extraBitCount, bits: extraBits } };
+  let extra = extraBitCount === 0 ? void 0 : { count: extraBitCount, bits: extraBits };
+  return { result: into, read, written, extra };
 }
 
 export function uint8ArrayToHex(arr) {

--- a/playground/polyfill-core.mjs
+++ b/playground/polyfill-core.mjs
@@ -169,8 +169,7 @@ export function base64ToUint8Array(str, alphabet, into = null, extraBitCount = 0
   if (codepoints.some(((c, i) => c === '=' && !(i === codepoints.length - 1 || i === codepoints.length - 2) || c !== '=' && !alphabetMap.has(c)))) {
     throw new Error('bad character');
   }
-  // TODO maybe pull this out into the different methods
-  let totalBytesForChunk = countFullBytesInBase64StringIncludingExtraBits(str, extraBitCount); // also validates padding, if present
+  let totalBytesForChunk = countFullBytesInBase64StringIncludingExtraBits(str, extraBitCount); // also kinda validates padding, if present
   let bytesToWrite;
   let outputIndex;
   if (into == null) {

--- a/playground/polyfill-core.mjs
+++ b/playground/polyfill-core.mjs
@@ -20,7 +20,6 @@ function assert(condition, message) {
   }
 }
 
-// todo not export
 export function alphabetFromIdentifier(alphabet) {
   if (alphabet === 'base64') {
     return base64Characters;
@@ -163,26 +162,18 @@ export function countFullBytesInBase64StringIncludingExtraBits(str, extraBitCoun
   }
 }
 
-export function base64ToUint8Array(str, alphabetIdentifier = 'base64', into = null, extra = null, inputOffset = 0, outputOffset = 0) {
-  if (typeof str !== 'string') {
-    throw new TypeError('expected str to be a string');
-  }
-  // TODO other typechecks
-  let alphabet = alphabetFromIdentifier(alphabetIdentifier);
-  let { count: extraBitCount, bits: extraBits } = extra ?? { count: 0, bits: 0 };
+export function base64ToUint8Array(str, alphabet, into = null, extraBitCount = 0, extraBits = 0, inputOffset = 0, outputOffset = 0) {
   let alphabetMap = new Map(alphabet.split('').map((c, i) => [c, i]));
   str = str.slice(inputOffset);
   let codepoints = [...str]; // NB does not validate characters before inputOffset - should it? probably already been validated, but might be faster to just run on the whole string
   if (codepoints.some(((c, i) => c === '=' && !(i === codepoints.length - 1 || i === codepoints.length - 2) || c !== '=' && !alphabetMap.has(c)))) {
     throw new Error('bad character');
   }
+  // TODO maybe pull this out into the different methods
   let totalBytesForChunk = countFullBytesInBase64StringIncludingExtraBits(str, extraBitCount); // also validates padding, if present
   let bytesToWrite;
   let outputIndex;
   if (into == null) {
-    if (outputOffset !== 0) {
-      throw new TypeError('outputOffset cannot be used with into');
-    }
     into = new Uint8Array(totalBytesForChunk);
     bytesToWrite = totalBytesForChunk;
   } else {

--- a/playground/polyfill-install.mjs
+++ b/playground/polyfill-install.mjs
@@ -32,6 +32,12 @@ Uint8Array.fromBase64 = function (string, opts) {
   if (typeof string !== 'string') {
     throw new Error('expected argument to be a string');
   }
+  if (string.endsWith('=')) {
+    // TODO should we validate padding even if absent? i.e. enforce length%4===0 unconditionally?
+    if (string.length % 4 !== 0 || string.endsWith('===')) {
+      throw new Error('bad padding');
+    }
+  }
   opts = getOptionsObject(opts);
   let { alphabet: alphabetIdentifier } = opts;
   let alphabet = typeof alphabetIdentifier === 'undefined' ? alphabetFromIdentifier('base64') : alphabetFromIdentifier(alphabetIdentifier);
@@ -47,7 +53,7 @@ Uint8Array.fromPartialBase64 = function (string, opts) {
   let alphabet = typeof alphabetIdentifier === 'undefined' ? alphabetFromIdentifier('base64') : alphabetFromIdentifier(alphabetIdentifier);
   let extraBitCount = 0, extraBits = 0;
   if (extra !== null && typeof extra === 'object') {
-    let { count: extraBitCount, bits: extraBits } = extra;
+    0, { count: extraBitCount, bits: extraBits } = extra;
     if (typeof extraBitCount !== 'number' || !(extraBitCount === 0 || extraBitCount === 2 || extraBitCount === 4 || extraBitCount === 6)) {
       throw new TypeError('bit count must be 0, 2, 4, or 6');
     }

--- a/playground/polyfill-install.mjs
+++ b/playground/polyfill-install.mjs
@@ -33,11 +33,11 @@ Uint8Array.fromPartialBase64 = function (string, opts) {
   if (typeof string !== 'string') {
     throw new Error('expected argument to be a string');
   }
-  let alphabet, more, extra;
+  let alphabet, extra, into, inputOffset, outputOffset;
   if (opts && typeof opts === 'object') {
-    0, { alphabet, more, extra } = opts;
+    0, { alphabet, extra, into, inputOffset, outputOffset } = opts;
   }
-  return base64ToUint8Array(string, alphabet, more, extra);
+  return base64ToUint8Array(string, alphabet, into, extra, inputOffset, outputOffset);
 };
 
 Uint8Array.prototype.toHex = function () {

--- a/playground/polyfill-install.mjs
+++ b/playground/polyfill-install.mjs
@@ -1,4 +1,14 @@
-import { checkUint8Array, uint8ArrayToBase64, base64ToUint8Array, uint8ArrayToHex, hexToUint8Array } from './polyfill-core.mjs';
+import { alphabetFromIdentifier, checkUint8Array, uint8ArrayToBase64, base64ToUint8Array, uint8ArrayToHex, hexToUint8Array } from './polyfill-core.mjs';
+
+function getOptionsObject(opts) {
+  if (typeof opts === 'undefined') {
+    return { __proto__: null };
+  }
+  if (opts !== null && typeof opts === 'object') {
+    return opts;
+  }
+  throw new TypeError('bad options object');
+}
 
 Uint8Array.prototype.toBase64 = function (opts) {
   checkUint8Array(this);
@@ -22,10 +32,9 @@ Uint8Array.fromBase64 = function (string, opts) {
   if (typeof string !== 'string') {
     throw new Error('expected argument to be a string');
   }
-  let alphabet;
-  if (opts && typeof opts === 'object') {
-    0, { alphabet } = opts;
-  }
+  opts = getOptionsObject(opts);
+  let { alphabet: alphabetIdentifier } = opts;
+  let alphabet = typeof alphabetIdentifier === 'undefined' ? alphabetFromIdentifier('base64') : alphabetFromIdentifier(alphabetIdentifier);
   return base64ToUint8Array(string, alphabet).result;
 };
 
@@ -33,11 +42,38 @@ Uint8Array.fromPartialBase64 = function (string, opts) {
   if (typeof string !== 'string') {
     throw new Error('expected argument to be a string');
   }
-  let alphabet, extra, into, inputOffset, outputOffset;
-  if (opts && typeof opts === 'object') {
-    0, { alphabet, extra, into, inputOffset, outputOffset } = opts;
+  opts = getOptionsObject(opts);
+  let { alphabet: alphabetIdentifier, extra, into, inputOffset, outputOffset } = opts;
+  let alphabet = typeof alphabetIdentifier === 'undefined' ? alphabetFromIdentifier('base64') : alphabetFromIdentifier(alphabetIdentifier);
+  let extraBitCount = 0, extraBits = 0;
+  if (extra !== null && typeof extra === 'object') {
+    let { count: extraBitCount, bits: extraBits } = extra;
+    if (typeof extraBitCount !== 'number' || !(extraBitCount === 0 || extraBitCount === 2 || extraBitCount === 4 || extraBitCount === 6)) {
+      throw new TypeError('bit count must be 0, 2, 4, or 6');
+    }
+    if (typeof extraBits !== 'number' || extraBits < 0 || (extraBits | 0) !== extraBits || (extraBitCount === 0 && extraBits !== 0) || (extraBitCount === 2 && extraBits >= 4) || (extraBitCount === 4 && extraBits >= 16) || (extraBitCount === 6 && extraBits >= 64)) {
+      throw new TypeError('bits not well-formed');
+    }
+  } else if (typeof extra !== 'undefined') {
+    throw new TypeError('extra must be an object');
   }
-  return base64ToUint8Array(string, alphabet, into, extra, inputOffset, outputOffset);
+  if (typeof into !== 'undefined') {
+    checkUint8Array(into);
+  }
+  if (typeof inputOffset !== 'undefined') {
+    if (typeof inputOffset !== 'number' || Math.floor(inputOffset) !== inputOffset || inputOffset < 0 || inputOffset >= string.length) {
+      throw new TypeError('bad inputOffset');
+    }
+  }
+  if (typeof outputOffset !== 'undefined') {
+    if (typeof into === 'undefined') {
+      throw new TypeError('outputOffset cannot be used with into');
+    }
+    if (typeof outputOffset !== 'number' || Math.floor(outputOffset) !== outputOffset || outputOffset < 0 || outputOffset >= outputOffset.length) {
+      throw new TypeError('bad outputOffset');
+    }
+  }
+  return base64ToUint8Array(string, alphabet, into, extraBitCount, extraBits, inputOffset, outputOffset);
 };
 
 Uint8Array.prototype.toHex = function () {

--- a/spec.html
+++ b/spec.html
@@ -116,6 +116,7 @@ contributors: Kevin Gibbons
 <emu-clause id="sec-uint8array.frompartialbase64">
   <h1>Uint8Array.fromPartialBase64 ( _value_ [ , _options_ ] )</h1>
   <emu-alg>
+    1. TODO: This method has not been updated for the BYOB changes discussed in <a href="https://github.com/tc39/proposal-arraybuffer-base64/issues/21">this issue</a>.
     1. Let _string_ be ? GetStringForBinaryEncoding(_value_).
     1. Let _opts_ be ? GetOptionsObject(_options_).
     1. Let _alphabet_ be ? Get(_opts_, *"alphabet"*).


### PR DESCRIPTION
Fixes https://github.com/tc39/proposal-arraybuffer-base64/issues/21 (at least for base64).

This adds `into`, `outputOffset`, and `inputOffset` parameters, as well as `read` and `written` return values, to the `fromPartialBase64` static method.

It also tweaks the `extra` parameter so we can keep track of individual extra bits, not just characters; thanks @jridgewell for the suggestion. Doing so allows us to completely fill passed buffers, even when they have lengths which are not a multiple of 3, which is a useful property. In addition, this lets us get rid of the `more` parameter for this method.

This only solves the problem for base64-string->Uint8Array. The other direction doesn't need it, since we don't have StringBuilder or any equivalent. But we probably do want to solve the problem for hex->Uint8Array, which will mean adding a `fromPartialHex` static method.

Also the names are bad but see https://github.com/tc39/proposal-arraybuffer-base64/issues/25 for that.

Here's the two complete examples from the playground in this PR:

Single input:
```js

let input = 'SGVsbG8gV29ybGQ=';
let buffer = new Uint8Array(4);
let outputOffset = 0;
let inputOffset = 0;
let extra, written, read;

while (inputOffset < input.length) {
  0, { extra, written, read } = Uint8Array.fromPartialBase64(input, {
    extra,
    into: buffer,
    inputOffset,
    outputOffset,
  });

  inputOffset += read;
  outputOffset += written;

  if (outputOffset === buffer.length) {
    // output is full; consume it
    console.log([...buffer]);
    outputOffset = 0;
  }
}
if (outputOffset > 0) {
  console.log([...buffer].slice(0, outputOffset));
}
```

Chunked input:
```js

let chunks = ['VGhpcyB', 'pcyBzb2', '1lIGV4YW1w', 'bGUgZGF0YS4='];
let output = new Uint8Array(4);
let outputOffset = 0;
let extra;
for (let chunk of chunks) {
  let written, read;
  let inputOffset = 0;

  while (inputOffset < chunk.length) {
    0, { extra, written, read } = Uint8Array.fromPartialBase64(chunk, {
      extra,
      into: output,
      inputOffset,
      outputOffset,
    });

    inputOffset += read;
    outputOffset += written;

    if (outputOffset === output.length) {
      // output is full; consume it
      console.log([...output]);
      outputOffset = 0;
    }
  }
}
if (outputOffset > 0) {
  console.log([...output].slice(0, outputOffset));
}
```