### PR TITLE
Remove streaming API, fill in spec text, etc

### DIFF
--- a/base64.md
+++ b/base64.md
@@ -1,0 +1,88 @@
+# Notes on Base64 as it exists
+
+Towards an implementation in JavaScript.
+
+## The RFCs
+
+There are two RFCs which are still generally relevant in modern times: [4648](https://datatracker.ietf.org/doc/html/rfc4648), which defines only the base64 and base64url encodings, and [2045](https://datatracker.ietf.org/doc/html/rfc2045#section-6.8), which defines [MIME](https://en.wikipedia.org/wiki/MIME) and includes a base64 encoding.
+
+RFC 4648 is "the base64 RFC". It obsoletes RFC [3548](https://datatracker.ietf.org/doc/html/rfc3548).
+
+- It defines both the standard (`+/`) and url-safe (`-_`) alphabets.
+- "Implementations MUST include appropriate pad characters at the end of encoded data unless the specification referring to this document explicitly states otherwise." Certain malformed padding MAY be ignored.
+- "Decoders MAY chose to reject an encoding if the pad bits have not been set to zero"
+- "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
+
+RFC 2045 is not usually relevant, but it's worth summarizing its behavior anyway:
+
+- Only the standard (`+/`) alphabet is supported.
+- It defines only an encoding. The encoding is specified to include `=`. No direction is given for decoders which encounter data which is not padded with `=`, or which has non-zero padding bits. In practice, decoders seem to ignore both.
+- "Any characters outside of the base64 alphabet are to be ignored in base64-encoded data."
+- MIME requires lines of length at most 76 characters, seperated by CRLF.
+
+RFCs [1421](https://datatracker.ietf.org/doc/html/rfc1421) and [7468](https://datatracker.ietf.org/doc/html/rfc7468), which define "Privacy-Enhanced Mail" and related things (think `-----BEGIN PRIVATE KEY-----`), are basically identical to the above except that they mandate lines of exactly 64 characters, except that the last line may be shorter.
+
+RFC [4880](https://datatracker.ietf.org/doc/html/rfc4880#section-6) defines OpenPGP messages and is just the RFC 2045 format plus a checksum. In practice, only whitespace is ignored, not all non-base64 characters.
+
+No other variations are contemplated in any other RFC or implementation that I'm aware of. That is, we have the following ways that base64 encoders can vary:
+
+- Standard or URL-safe alphabet
+- Whether `=` is included in output
+- Whether to add linebreaks after a certain number of characters
+
+and the following ways that base64 decoders can vary:
+
+- Standard or URL-safe alphabet
+- Whether `=` is required in input, and how to handle malformed padding (e.g. extra `=`)
+- Whether to fail on non-zero padding bits
+- Whether lines must be of a limited length
+- How non-base64-alphabet characters are handled (sometimes with special handling for only a subset, like whitespace)
+
+## Programming languages
+
+Note that neither C++ nor Rust have built-in base64 support. In C++ the Boost library is quite common in large projects and parts sometimes get pulled in to the standard library, and in Rust the [base64 crate](https://docs.rs/base64/latest/base64/) is the clear choice of everyone, so I'm mentioning those as well.
+
+"✅ / ⚙️" means the default is yes but it's configurable. A bare "⚙️" means it's configurable and there is no default.
+
+|                     | supports urlsafe | `=`s in output | whitespace in output | can omit `=`s in input | can have non-zero padding bits | can have arbitrary characters in input | can have whitespace in input |
+| ------------------- | ---------------- | -------------- | -------------------- | ---------------------- | ------------------------------ | -------------------------------------- | ---------------------------- |
+| C++ (Boost)         | ❌               | ❌             | ❌                   | ?[^cpp]                | ?                              | ❌                                     | ❌                           |
+| Ruby                | ✅               | ✅ / ⚙️[^ruby] | ✅ / ⚙️[^ruby2]      | ✅ / ⚙️                | ✅ / ⚙️                        | ❌                                     | ✅ / ⚙️                      |
+| Python              | ✅               | ✅             | ❌                   | ❌                     | ✅                             | ✅ / ⚙️                                | ✅ / ⚙️                      |
+| Rust (base64 crate) | ✅               | ⚙️             | ❌                   | ⚙️                     | ⚙️                             | ❌                                     | ❌                           |
+| Java                | ✅               | ✅ / ⚙️        | ❌ / ⚙️[^java]       | ✅                     | ✅                             | ❌                                     | ❌ / ⚙️                      |
+| Go                  | ✅               | ✅             | ❌                   | ✅ / ⚙️                | ✅ / ⚙️                        | ❌                                     | ✅[^go]                      |
+| C#                  | ❌               | ✅             | ❌                   | ❌                     | ✅                             | ❌                                     | ✅                           |
+| PHP                 | ❌               | ✅             | ❌                   | ✅                     | ✅                             | ✅ / ⚙️                                | ✅ / ⚙️                      |
+| Swift               | ❌               | ✅             | ❌ / ⚙️              | ❌                     | ✅                             | ❌ / ⚙️                                | ❌ / ⚙️                      |
+
+[^cpp]: Boost adds extra null bytes to the output when padding is present, and treats non-zero padding bits as meaningful (i.e. it produces more output when they are present)
+[^ruby]: Ruby only allows configuring padding with the urlsafe alphabet
+[^ruby2]: Ruby adds linebreaks every 60 characters
+[^java]: Java allows MIME-format output, with `\r\n` sequences after every 76 characters of output
+[^go]: Go only allows linebreaks specifically
+
+## JS libraries
+
+Only including libraries with a least a million downloads per week and at least 100 distinct dependents.
+
+|                             | supports urlsafe  | `=`s in output | whitespace in output | can omit `=`s in input | can have non-zero padding bits | can have arbitrary characters in input | can have whitespace in input |
+| --------------------------- | ----------------- | -------------- | -------------------- | ---------------------- | ------------------------------ | -------------------------------------- | ---------------------------- |
+| `atob`/`btoa`               | ❌                | ✅             | ❌                   | ✅                     | ✅                             | ❌                                     | ✅                           |
+| Node's Buffer               | ✅[^node]         | ✅             | ❌                   | ✅                     | ✅                             | ✅                                     | ✅                           |
+| base64-js (38m/wk)          | ✅ (for decoding) | ✅             | ❌                   | ❌                     | ✅                             | ❌[^base64-js]                         | ❌                           |
+| @smithy/util-base64 (8m/wk) | ❌                | ✅             | ❌                   | ❌                     | ✅                             | ❌                                     | ❌                           |
+| crypto-js (6m/wk)           | ✅                | ✅             | ❌                   | ✅                     | ✅                             | ❌[^crypto-js]                         | ❌                           |
+| js-base64 (5m/wk)           | ✅                | ✅ / ⚙️        | ❌                   | ✅                     | ✅                             | ✅                                     | ✅                           |
+| base64-arraybuffer (4m/wk)  | ❌                | ✅             | ❌                   | ✅                     | ✅                             | ❌[^base64-arraybuffer]                | ❌                           |
+| base64url (2m/wk)           | ✅                | ❌ / ⚙️        | ❌                   | ✅                     | ✅                             | ✅                                     | ✅                           |
+| base-64 (2m/wk)             | ❌                | ✅             | ❌                   | ✅                     | ✅                             | ✅                                     | ✅                           |
+
+[^node]: Node allows mixing alphabets within the same string in input
+[^base64-js]: Illegal characters are interpreted as `A`
+[^crypto-js]: Illegal characters are interpreted as `A`
+[^base64-arraybuffer]: Illegal characters are interpreted as `A`
+
+## "Whitespace"
+
+In all of the above, "whitespace" means only _ASCII_ whitespace. I don't think anyone has special handling for Unicode but non-ASCII whitespace.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "proposal-arraybuffer-base64",
       "dependencies": {
-        "@tc39/ecma262-biblio": "2.1.2553",
-        "ecmarkup": "^17.0.0",
+        "@tc39/ecma262-biblio": "2.1.2653",
+        "ecmarkup": "^18.0.0",
         "jsdom": "^21.1.1",
         "prismjs": "^1.29.0"
       }
@@ -163,9 +164,9 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "2.1.2553",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2553.tgz",
-      "integrity": "sha512-c2h05szLmHNnNO+7gE7mzgK3qDoZOEQrPKIIIZtY8gRpe5F2qTNIfj5tqxVYV7WUTC+/ZsR9/kojJ823hL2hvg=="
+      "version": "2.1.2653",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2653.tgz",
+      "integrity": "sha512-/CIVRwkV3fTaYNxFSEvbDsTPFBNfeJOjQACZXs11+NKkbHhFh9pvr8j6NbJ/fekJLgAu6x2QXvGdA/kEGR/08g=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -508,9 +509,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.0.tgz",
-      "integrity": "sha512-eQr9Vn9IPIH3rrbYEGPqfAwDJ9pg1zrOSZXc8HQwVMQ9d5tb+BsoPeKw5W1SinL09yZalcbLyqnX7rC393VRdA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.0.0.tgz",
+      "integrity": "sha512-VSItKQ+39dv1FeR1YbGGlJ/rx17wsPSkS7morrOCwLGHh+7ehy89hao+rQ0/ptiBAN3nbytXzwUBUTC3XNmxaA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "name": "proposal-arraybuffer-base64",
   "scripts": {
     "build-playground": "mkdir -p dist && cp playground/* dist && node scripts/static-highlight.js playground/index-raw.html > dist/index.html && rm dist/index-raw.html",
-    "build-spec": "mkdir -p dist/spec && ecmarkup --lint-spec --strict --load-biblio @tc39/ecma262-biblio --verbose --js-out dist/spec/ecmarkup.js --css-out dist/spec/ecmarkup.css spec.html dist/spec/index.html",
+    "build-spec": "mkdir -p dist/spec && ecmarkup --lint-spec --strict --load-biblio @tc39/ecma262-biblio --verbose spec.html --assets-dir dist/spec dist/spec/index.html",
     "build": "npm run build-playground && npm run build-spec",
     "format": "emu-format --write spec.html",
     "check-format": "emu-format --check spec.html"
   },
   "dependencies": {
-    "@tc39/ecma262-biblio": "2.1.2553",
-    "ecmarkup": "^17.0.0",
+    "@tc39/ecma262-biblio": "2.1.2653",
+    "ecmarkup": "^18.0.0",
     "jsdom": "^21.1.1",
     "prismjs": "^1.29.0"
   }

--- a/playground/index-raw.html
+++ b/playground/index-raw.html
@@ -115,7 +115,7 @@ try {
 </code></pre>
 
 <h3>Streaming</h3>
-<p>There is no support for streaming. However, it can be implemented in userland.</p>
+<p>There is no support for streaming. However, <a href="https://github.com/tc39/proposal-arraybuffer-base64/blob/main/stream.mjs">it can be implemented in userland</a>.</p>
 
 <footer>
   <p>Thanks for reading! If you got this far, you should try out the proposal in your browser's developer tools on this page, and submit feedback on <a href="https://github.com/tc39/proposal-arraybuffer-base64">GitHub</a>.</p>

--- a/playground/index-raw.html
+++ b/playground/index-raw.html
@@ -48,7 +48,7 @@ if (navigator.clipboard) {
 <h1>Proposed Support for Base64 in JavaScript</h1>
 
 <h2 id="introduction">Introduction</h2>
-<p>This page documents an early-stage proposal for native base64 and hex encoding and decoding for binary data in JavaScript, and includes a <strong>non-production, slightly inaccurate</strong> polyfill you can experiment with in the browser's console. Some details of the polyfill, particularly around coercion and order of observable effects, are not identical to the proposed spec text.</p>
+<p>This page documents a stage-2 proposal for native base64 and hex encoding and decoding for binary data in JavaScript, and includes a <strong>non-production</strong> polyfill you can experiment with in the browser's console.</p>
 <p>The proposal would provide methods for encoding and decoding Uint8Arrays as base64 and hex strings.</p>
 <p>Feedback on <a href="https://github.com/tc39/proposal-arraybuffer-base64">the proposal's repository</a> is appreciated.</p>
 
@@ -84,8 +84,7 @@ console.log(Uint8Array.fromHex(string));
 
 <h3>Options</h3>
 <p>The base64 methods take an optional options bag which allows specifying the alphabet as either "base64" (the default) or "base64url" (<a href="https://datatracker.ietf.org/doc/html/rfc4648#section-5">the URL-safe variant</a>).</p>
-<p>In the future this may allow specifying arbitrary alphabets.</p>
-<p>In later versions of this proposal the options bag may also allow additional options, such as specifying whether to generate / enforce padding characters and how to handle whitespace.</p>
+<p>When encoding, the options bag also allows specifying <code>strict: false</code> (the default) or <code>strict: true</code>. When using <code>strict: false</code>, whitespace is legal and padding is optional. When using <code>strict: true</code>, whitespace is forbidden and standard padding (including any overflow bits in the last character being 0) is enforced - i.e., only <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-3.5">canonical</a> encodings are allowed.</p>
 <p>The hex methods do not have any options.</p>
 
 <pre class="language-js"><code class="language-js">
@@ -94,102 +93,29 @@ console.log(array.toBase64({ alphabet: 'base64' }));
 // '+/+/'
 console.log(array.toBase64({ alphabet: 'base64url' }));
 // '-_-_'
+
+console.log(Uint8Array.fromBase64('SGVsbG8g\nV29ybG R'));
+// works, despite whitespace, missing padding, and non-zero overflow bits
+
+try {
+  Uint8Array.fromBase64('SGVsbG8g\nV29ybG Q=', { strict: true });
+} catch {
+  console.log('with strict: true, whitespace is rejected');
+}
+try {
+  Uint8Array.fromBase64('SGVsbG8gV29ybGQ', { strict: true });
+} catch {
+  console.log('with strict: true, padding is required');
+}
+try {
+  Uint8Array.fromBase64('SGVsbG8gV29ybGR=', { strict: true });
+} catch {
+  console.log('with strict: true, non-zero overflow bits are rejected');
+}
 </code></pre>
 
 <h3>Streaming</h3>
-<p>Two additional methods, <code>toPartialBase64</code> and <code>fromPartialBase64</code>, allow encoding and decoding chunks of base64. This requires managing state, which is handled by returning a <code>{ result, extra }</code> pair. The options bag for these methods takes two additional arguments, one which specifies whether more data is expected and one which specifies any extra values returned by a previous call.</p>
-<p>These methods are intended for lower-level use and are less convenient to use.</p>
-<p>Streaming versions of the hex APIs are not included since they are straightforward to do manually.</p>
-
-<p>Streaming an ArrayBuffer into chunks of base64 strings:</p>
-<pre class="language-js"><code class="language-js">
-let buffer = (new Float64Array([0.1, 0.2, 0.3, 0.4])).buffer;
-let chunkSize = 6;
-let resultChunks = [];
-
-let result, extra;
-for (let offset = 0; offset < buffer.byteLength; offset += chunkSize) {
-  let length = Math.min(chunkSize, buffer.byteLength - offset);
-  let view = new Uint8Array(buffer, offset, length);
-  ({ result, extra } = view.toPartialBase64({ more: true, extra }));
-  resultChunks.push(result);
-}
-({ result } = extra.toPartialBase64({ more: false }));
-resultChunks.push(result);
-console.log(resultChunks);
-// ['mpmZmZmZ', 'uT+amZmZ', 'mZnJPzMz', 'MzMzM9M/', 'mpmZmZmZ', '', '2T8=']
-</code></pre>
-
-<p>Streaming base64 strings into Uint8Arrays:</p>
-<pre class="language-js"><code class="language-js">
-let chunks = ['mpmZmZmZuT+am', 'ZmZmZnJPzMz', 'MzMz', 'M9M/mpmZmZmZ', '2T8='];
-// individual chunks are not necessarily correctly-padded base64 strings
-
-let output = new Uint8Array(new ArrayBuffer(0, { maxByteLength: 1024 }));
-let result, extra;
-for (let c of chunks) {
-  ({ result, extra } = Uint8Array.fromPartialBase64(c, { more: true, extra }));
-  let offset = output.length;
-  let newLength = offset + result.length;
-  output.buffer.resize(newLength);
-  output.set(result, offset);
-}
-// if padding was optional,
-// you'd need to do a final `fromPartialBase64` call here with `more: false`
-
-console.log(new Float64Array(output.buffer));
-// Float64Array([0.1, 0.2, 0.3, 0.4])
-</code></pre>
-
-<p>Note that the above snippet makes use of the <a href="https://github.com/tc39/proposal-resizablearraybuffer">Growable ArrayBuffers</a> proposal for illustration, which not all browsers support as of this writing.</p>
-
-<p>A more involved example, creating a TransformStream which encodes contiguous Uint8Arrays:</p>
-<pre class="language-js"><code class="language-js">
-class BufferToStringTransformStream extends TransformStream {
-  #extra = null;
-  constructor(alphabet) {
-    super({
-      transform: (chunk, controller) => {
-        let { result, extra } = chunk.toPartialBase64({
-          alphabet,
-          extra: this.#extra,
-          more: true,
-        });
-        this.#extra = extra;
-        controller.enqueue(result);
-      },
-      flush: (controller) => {
-        if (this.#extra == null) return; // stream was empty
-        let { result } = this.#extra.toPartialBase64({ alphabet });
-        controller.enqueue(result);
-      },
-    });
-  }
-}
-
-// use:
-let source = new ReadableStream({
-  start(controller) {
-    controller.enqueue(new Uint8Array([1, 2]));
-    controller.enqueue(new Uint8Array([3, 4]));
-    controller.close();
-  },
-});
-
-let chunks = [];
-let sink = new WritableStream({
-  write(chunk) {
-    chunks.push(chunk);
-  },
-  close() {
-    console.log(chunks.join('')); // 'AQIDBA=='
-  },
-});
-
-source
-  .pipeThrough(new BufferToStringTransformStream())
-  .pipeTo(sink);
-</code></pre>
+<p>There is no support for streaming. However, it can be implemented in userland.</p>
 
 <footer>
   <p>Thanks for reading! If you got this far, you should try out the proposal in your browser's developer tools on this page, and submit feedback on <a href="https://github.com/tc39/proposal-arraybuffer-base64">GitHub</a>.</p>

--- a/playground/polyfill-install.mjs
+++ b/playground/polyfill-install.mjs
@@ -1,53 +1,17 @@
-import { checkUint8Array, uint8ArrayToBase64, base64ToUint8Array, uint8ArrayToHex, hexToUint8Array } from './polyfill-core.mjs';
+import { uint8ArrayToBase64, base64ToUint8Array, uint8ArrayToHex, hexToUint8Array } from './polyfill-core.mjs';
 
-Uint8Array.prototype.toBase64 = function (opts) {
-  checkUint8Array(this);
-  let alphabet;
-  if (opts && typeof opts === 'object') {
-    0, { alphabet } = opts;
-  }
-  return uint8ArrayToBase64(this, alphabet).result;
+Uint8Array.prototype.toBase64 = function (options) {
+  return uint8ArrayToBase64(this, options);
 };
 
-Uint8Array.prototype.toPartialBase64 = function (opts) {
-  checkUint8Array(this);
-  let alphabet, more, extra;
-  if (opts && typeof opts === 'object') {
-    0, { alphabet, more, extra } = opts;
-  }
-  return uint8ArrayToBase64(this, alphabet, more, extra);
-};
-
-Uint8Array.fromBase64 = function (string, opts) {
-  if (typeof string !== 'string') {
-    throw new Error('expected argument to be a string');
-  }
-  let alphabet;
-  if (opts && typeof opts === 'object') {
-    0, { alphabet } = opts;
-  }
-  return base64ToUint8Array(string, alphabet).result;
-};
-
-Uint8Array.fromPartialBase64 = function (string, opts) {
-  if (typeof string !== 'string') {
-    throw new Error('expected argument to be a string');
-  }
-  let alphabet, more, extra;
-  if (opts && typeof opts === 'object') {
-    0, { alphabet, more, extra } = opts;
-  }
-  return base64ToUint8Array(string, alphabet, more, extra);
+Uint8Array.fromBase64 = function (string, options) {
+  return base64ToUint8Array(string, options);
 };
 
 Uint8Array.prototype.toHex = function () {
-  checkUint8Array(this);
   return uint8ArrayToHex(this);
 };
 
 Uint8Array.fromHex = function (string) {
-  if (typeof string !== 'string') {
-    throw new Error('expected argument to be a string');
-  }
   return hexToUint8Array(string);
 };

--- a/spec.html
+++ b/spec.html
@@ -25,10 +25,10 @@ contributors: Kevin Gibbons
     1. If _alphabet_ is not a String, throw a *TypeError* exception.
     1. If _alphabet_ is neither *"base64"* nor *"base64url"*, throw a *TypeError* exception.
     1. If _alphabet_ is *"base64"*, then
-      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64 encoding specified in section 4 of RFC 4648. Padding is included.
+      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64 encoding specified in section 4 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a>. Padding is included.
     1. Else,
       1. Assert: _alphabet_ is *"base64url"*.
-      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64url encoding specified in section 5 of RFC 4648. Padding is included.
+      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64url encoding specified in section 5 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a>. Padding is included.
     1. Return CodePointsToString(_outAscii_).
   </emu-alg>
 </emu-clause>
@@ -85,7 +85,7 @@ contributors: Kevin Gibbons
       1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_ twice.
     1. Else if _lastChunkSize_ is 3, then
       1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_.
-    1. Let _bytes_ be the unique (possibly empty) sequence of bytes resulting from decoding _input_ as base64 (such that applying the base64 encoding specified in section 4 of RFC 4648 to _bytes_ would produce _input_).
+    1. Let _bytes_ be the unique (possibly empty) sequence of bytes resulting from decoding _input_ as base64 (such that applying the base64 encoding specified in section 4 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a> to _bytes_ would produce _input_).
     1. Let _byteLength_ be the length of _bytes_.
     1. If _lastChunkSize_ is 2, then
       1. If _strict_ is *true* and _bytes_[_byteLength_ - 2] is not 0, throw a *SyntaxError* exception.

--- a/spec.html
+++ b/spec.html
@@ -22,53 +22,14 @@ contributors: Kevin Gibbons
     1. Let _opts_ be ? GetOptionsObject(_options_).
     1. Let _alphabet_ be ? Get(_opts_, *"alphabet"*).
     1. If _alphabet_ is *undefined*, set _alphabet_ to *"base64"*.
-    1. Set _alphabet_ to ? ToString(_alphabet_).
+    1. If _alphabet_ is not a String, throw a *TypeError* exception.
     1. If _alphabet_ is neither *"base64"* nor *"base64url"*, throw a *TypeError* exception.
     1. If _alphabet_ is *"base64"*, then
-      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64 encoding specified in section 4 of RFC 4648.
+      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64 encoding specified in section 4 of RFC 4648. Padding is included.
     1. Else,
       1. Assert: _alphabet_ is *"base64url"*.
-      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64url encoding specified in section 5 of RFC 4648.
+      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64url encoding specified in section 5 of RFC 4648. Padding is included.
     1. Return CodePointsToString(_outAscii_).
-    1. NOTE: CodePointsToString is used only because RFC 4648 does not produce a sequence of code units. Implementations may be able to produce an ECMAScript string directly.
-  </emu-alg>
-</emu-clause>
-
-<emu-clause id="sec-uint8array.prototype.topartialbase64">
-  <h1>Uint8Array.prototype.toPartialBase64 ( [ _options_ ] )</h1>
-  <emu-alg>
-    1. Let _O_ be the *this* value.
-    1. Let _toEncode_ be ? GetUint8ArrayBytes(_O_).
-    1. Let _opts_ be ? GetOptionsObject(_options_).
-    1. Let _alphabet_ be ? Get(_opts_, *"alphabet"*).
-    1. If _alphabet_ is *undefined*, set _alphabet_ to *"base64"*.
-    1. Set _alphabet_ to ? ToString(_alphabet_).
-    1. If _alphabet_ is neither *"base64"* nor *"base64url"*, throw a *TypeError* exception.
-    1. Let _more_ be ToBoolean(? Get(_opts_, *"more"*)).
-    1. Let _extra_ be ? Get(_opts_, *"extra"*).
-    1. If _extra_ is neither *undefined* nor *null*, then
-      1. TODO: consider handling array-of-bytes.
-      1. Let _extraBytes_ be ? GetUint8ArrayBytes(_extra_).
-      1. Set _toEncode_ to the list-concatenation of _extraBytes_ and _toEncode_.
-    1. If _more_ is *true*, then
-      1. Let _toEncodeLength_ be the length of _toEncode_.
-      1. Let _overflowLength_ be _toEncodeLength_ modulo 3.
-      1. Let _overflowBytes_ be a List whose elements are the last _overflowLength_ elements of _toEncode_.
-      1. TODO: convert _overflowBytes_ to a new Uint8Array here.
-      1. Remove the last _overflowLength_ elements of _toEncode_.
-    1. Else,
-      1. Let _overflowBytes_ be *null*.
-    1. If _alphabet_ is *"base64"*, then
-      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64 encoding specified in section 4 of RFC 4648.
-    1. Else,
-      1. Assert: _alphabet_ is *"base64url"*.
-      1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64url encoding specified in section 5 of RFC 4648.
-    1. Let _result_ be CodePointsToString(_outAscii_).
-    1. NOTE: CodePointsToString is used only because RFC 4648 does not produce a sequence of code units. Implementations may be able to produce an ECMAScript string directly.
-    1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-    1. Perform ! CreateDataPropertyOrThrow(_obj_, *"result"*, _result_).
-    1. Perform ! CreateDataPropertyOrThrow(_obj_, *"extra"*, _overflowBytes_).
-    1. Return _obj_.
   </emu-alg>
 </emu-clause>
 
@@ -87,80 +48,59 @@ contributors: Kevin Gibbons
 </emu-clause>
 
 <emu-clause id="sec-uint8array.frombase64">
-  <h1>Uint8Array.fromBase64 ( _value_ [ , _options_ ] )</h1>
+  <h1>Uint8Array.fromBase64 ( _string_ [ , _options_ ] )</h1>
+  <p>The <dfn id="standard-base64-alphabet">standard base64 alphabet</dfn> is a List whose elements are the code points corresponding to every letter and number in the Unicode Basic Latin block along with *"+"* and *"/"*; that is, it is StringToCodePoints(*"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/").</p>
   <emu-alg>
-    1. Let _string_ be ? GetStringForBinaryEncoding(_value_).
+    1. If _string_ is not a String, throw a *TypeError* exception.
     1. Let _opts_ be ? GetOptionsObject(_options_).
     1. Let _alphabet_ be ? Get(_opts_, *"alphabet"*).
     1. If _alphabet_ is *undefined*, set _alphabet_ to *"base64"*.
-    1. Set _alphabet_ to ? ToString(_alphabet_).
+    1. If _alphabet_ is not a String, throw a *TypeError* exception.
     1. If _alphabet_ is neither *"base64"* nor *"base64url"*, throw a *TypeError* exception.
-    1. TODO: normalize whitespace / padding here.
-    1. TODO: figure out what the right defaults for whitespace/padding are.
-    1. Let _characters_ be StringToCodePoints(_string_).
-    1. NOTE: StringToCodePoints is used only because RFC 4648 does not produce a sequence of code units. Implementations may be able to base64-decode _string_ directly.
-    1. If _alphabet_ is *"base64"*, then
-      1. If _characters_ cannot result from applying the base64 encoding specified in section 4 of RFC 4648 to some sequence of bytes, throw a *SyntaxError* exception.
-      1. Let _bytes_ be the unique sequence of bytes such that applying the base64 encoding specified in section 4 of RFC 4648 to that sequence would produce _characters_.
+    1. Let _strict_ be ToBoolean(? Get(_opts_, *"strict"*)).
+    1. NOTE: The order of validation and decoding in the algorithm below is not observable. Implementations are encouraged to perform them in whatever order is most efficient, possibly interleaving validation and stripping whitespace with decoding, as long as the behaviour is observably equivalent.
+    1. Let _input_ be StringToCodePoints(_string_).
+    1. If _alphabet_ is *"base64url"*, then
+      1. If _input_ contains U+002B (PLUS SIGN) or U+002F (SOLIDUS), throw a *SyntaxError* exception.
+      1. Replace all occurrences of U+002D (HYPHEN-MINUS) in _input_ with U+002B (PLUS SIGN).
+      1. Replace all occurrences of U+005F (LOW LINE) in _input_ with U+002F (SOLIDUS).
+    1. NOTE: When _strict_ is *false*, the algorithm below is equivalent to the <a href="https://infra.spec.whatwg.org/#forgiving-base64-decode">forgiving-base64 decode</a> operation in HTML.
+    1. If _strict_ is *false*, then
+      1. Remove all occurrences of U+0009 (TAB), U+000A (LF), U+000C (FF), U+000D (CR), and U+0020 (SPACE) from _input_.
+    1. Let _inputLength_ be the length of _input_.
+    1. If _inputLength_ modulo 4 is 0, then
+      1. If _input_ is not empty and the last element of _input_ is U+003D (EQUALS SIGN), then
+        1. Remove the last element of _input_.
+        1. Set _inputLength_ to _inputLength_ - 1.
+        1. If _input_ is not empty and the last element of _input_ is U+003D (EQUALS SIGN), then
+          1. Remove the last element of _input_.
+          1. Set _inputLength_ to _inputLength_ - 1.
     1. Else,
-      1. Assert: _alphabet_ is *"base64url*".
-      1. If _characters_ cannot result from applying the base64url encoding specified in section 5 of RFC 4648 to some sequence of bytes, throw a *SyntaxError* exception.
-      1. Let _bytes_ be the unique sequence of bytes such that applying the base64url encoding specified in section 5 of RFC 4648 to that sequence would produce _characters_.
-    1. Let _resultLength_ be the number of bytes in _bytes_.
-    1. Let _result_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _resultLength_).
+      1. If _strict_ is *true*, throw a *SyntaxError* exception.
+    1. If _input_ contains any elements which are not also elements of the standard base64 alphabet, throw a *SyntaxError* exception.
+    1. Let _lastChunkSize_ be _inputLength_ modulo 4.
+    1. If _lastChunkSize_ is 1, then
+      1. Throw a *SyntaxError* exception.
+    1. Else if _lastChunkSize_ is 2 or _lastChunkSize_ is 3, then
+      1. Append U+0041 (LATIN CAPITAL LETTER A) to _lastChunkSize_ a total of (4 - _lastChunkSize_) times.
+    1. Let _bytes_ be the unique sequence of bytes such that applying the base64 encoding specified in section 4 of RFC 4648 to that sequence would produce _input_.
+    1. Let _byteLength_ be the length _bytes_.
+    1. If _lastChunkSize_ is 2, then
+      1. If _strict_ is *true* and _bytes_[_byteLength_ - 2] is not 0, throw a *SyntaxError* exception.
+      1. Remove the final 2 elements of _bytes_.
+    1. Else if _lastChunkSize_ is 3, then
+      1. If _strict_ is *true* and _bytes_[_byteLength_ - 1] is not 0, throw a *SyntaxError* exception.
+      1. Remove the final element of _bytes_.
+    1. Let _result_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _byteLength_).
     1. Set the value at each index of _result_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _bytes_.
     1. Return _result_.
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-uint8array.frompartialbase64">
-  <h1>Uint8Array.fromPartialBase64 ( _value_ [ , _options_ ] )</h1>
-  <emu-alg>
-    1. Let _string_ be ? GetStringForBinaryEncoding(_value_).
-    1. Let _opts_ be ? GetOptionsObject(_options_).
-    1. Let _alphabet_ be ? Get(_opts_, *"alphabet"*).
-    1. If _alphabet_ is *undefined*, set _alphabet_ to *"base64"*.
-    1. Set _alphabet_ to ? ToString(_alphabet_).
-    1. If _alphabet_ is neither *"base64"* nor *"base64url"*, throw a *TypeError* exception.
-    1. Let _more_ be ToBoolean(? Get(_opts_, *"more"*)).
-    1. Let _extra_ be ? Get(_opts_, *"extra"*).
-    1. If _extra_ is neither *undefined* nor *null*, then
-      1. Let _extraString_ be ? GetStringForBinaryEncoding(_extra_).
-      1. Set _string_ to the list-concatenation of _extraString_ and _string_.
-    1. If _more_ is *true*, then
-      1. TODO: think about handling of padding on _string_ / _extra_ in this case. This currently assumes no padding on either.
-      1. Let _stringLength_ be the length of _string_.
-      1. Let _overflowLength_ be _stringLength_ modulo 4.
-      1. Let _newLength_ be _stringLength_ - _overflowLength_.
-      1. Let _overflow_ be the substring of _string_ from _newLength_.
-      1. Set _string_ to the substring of _string_ from 0 to _newLength_.
-    1. Else,
-      1. Let _overflow_ be *null*.
-    1. TODO: normalize whitespace / strip padding here.
-    1. TODO: figure out what the right defaults for whitespace/padding are.
-    1. Let _characters_ be StringToCodePoints(_string_).
-    1. NOTE: StringToCodePoints is used only because RFC 4648 does not produce a sequence of code units. Implementations may be able to base64-decode _string_ directly.
-    1. If _alphabet_ is *"base64"*, then
-      1. If _characters_ cannot result from applying the base64 encoding specified in section 4 of RFC 4648 to some sequence of bytes, throw a *SyntaxError* exception.
-      1. Let _bytes_ be the unique sequence of bytes such that applying the base64 encoding specified in section 4 of RFC 4648 to that sequence would produce _characters_.
-    1. Else,
-      1. Assert: _alphabet_ is *"base64url*".
-      1. If _characters_ cannot result from applying the base64url encoding specified in section 5 of RFC 4648 to some sequence of bytes, throw a *SyntaxError* exception.
-      1. Let _bytes_ be the unique sequence of bytes such that applying the base64url encoding specified in section 5 of RFC 4648 to that sequence would produce _characters_.
-    1. Let _resultLength_ be the number of bytes in _bytes_.
-    1. Let _result_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _resultLength_).
-    1. Set the value at each index of _result_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _bytes_.
-    1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-    1. Perform ! CreateDataPropertyOrThrow(_obj_, *"result"*, _result_).
-    1. Perform ! CreateDataPropertyOrThrow(_obj_, *"extra"*, _overflow_).
-    1. Return _obj_.
-  </emu-alg>
-</emu-clause>
-
 <emu-clause id="sec-uint8array.fromhex">
-  <h1>Uint8Array.fromHex ( _value_ )</h1>
+  <h1>Uint8Array.fromHex ( _string_ )</h1>
   <emu-alg>
-    1. Let _string_ be ? GetStringForBinaryEncoding(_value_).
+    1. If _string_ is not a String, throw a *TypeError* exception.
     1. TODO: consider stripping whitespace here.
     1. Let _stringLen_ be the length of _string_.
     1. If _stringLen_ modulo 2 is not 0, throw a *SyntaxError* exception.
@@ -194,22 +134,6 @@ contributors: Kevin Gibbons
     1. Let _offset_ be _ta_.[[ByteOffset]].
     1. Let _length_ be _ta_.[[ArrayLength]].
     1. Return a List whose elements are the byte values in _block_ starting at _offset_ and continuing for a total of _length_ bytes, in order.
-  </emu-alg>
-</emu-clause>
-
-<emu-clause id="sec-getstringforbinaryencoding" type="abstract operation">
-  <h1>
-    GetStringForBinaryEncoding (
-      _arg_: an ECMAScript language value,
-    ): either a normal completion containing a String or a throw completion
-  </h1>
-  <dl class="header"></dl>
-  <emu-alg>
-    1. If _arg_ is an Object, let _string_ be ? ToPrimitive(_arg_, ~string~); else let _string_ be _arg_.
-    1. NOTE: Because `[` is not a valid base64 or hex character, the Strings returned by %Object.prototype.toString% will produce a SyntaxError during encoding. Implementations are encouraged to provide an informative error message in that situations.
-    1. if _string_ is not a String, throw a TypeError exception.
-    1. NOTE: The above step is included to prevent errors such as accidentally passing `null` to `fromBase64` and receiving a Uint8Array containing the bytes « 0x9e, 0xe9, 0x65 ».
-    1. Return _string_.
   </emu-alg>
 </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -85,7 +85,7 @@ contributors: Kevin Gibbons
       1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_ twice.
     1. Else if _lastChunkSize_ is 3, then
       1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_.
-    1. Let _bytes_ be the unique (possibly empty) sequence of bytes such that applying the base64 encoding specified in section 4 of RFC 4648 to that sequence would produce _input_.
+    1. Let _bytes_ be the unique (possibly empty) sequence of bytes resulting from decoding _input_ as base64 (such that applying the base64 encoding specified in section 4 of RFC 4648 to _bytes_ would produce _input_).
     1. Let _byteLength_ be the length of _bytes_.
     1. If _lastChunkSize_ is 2, then
       1. If _strict_ is *true* and _bytes_[_byteLength_ - 2] is not 0, throw a *SyntaxError* exception.

--- a/spec.html
+++ b/spec.html
@@ -81,16 +81,20 @@ contributors: Kevin Gibbons
     1. Let _lastChunkSize_ be _inputLength_ modulo 4.
     1. If _lastChunkSize_ is 1, then
       1. Throw a *SyntaxError* exception.
-    1. Else if _lastChunkSize_ is 2 or _lastChunkSize_ is 3, then
-      1. Append U+0041 (LATIN CAPITAL LETTER A) to _lastChunkSize_ a total of (4 - _lastChunkSize_) times.
-    1. Let _bytes_ be the unique sequence of bytes such that applying the base64 encoding specified in section 4 of RFC 4648 to that sequence would produce _input_.
-    1. Let _byteLength_ be the length _bytes_.
+    1. Else if _lastChunkSize_ is 2, then
+      1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_ twice.
+    1. Else if _lastChunkSize_ is 3, then
+      1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_.
+    1. Let _bytes_ be the unique (possibly empty) sequence of bytes such that applying the base64 encoding specified in section 4 of RFC 4648 to that sequence would produce _input_.
+    1. Let _byteLength_ be the length of _bytes_.
     1. If _lastChunkSize_ is 2, then
       1. If _strict_ is *true* and _bytes_[_byteLength_ - 2] is not 0, throw a *SyntaxError* exception.
       1. Remove the final 2 elements of _bytes_.
+      1. Set _byteLength_ to _byteLength_ - 2.
     1. Else if _lastChunkSize_ is 3, then
       1. If _strict_ is *true* and _bytes_[_byteLength_ - 1] is not 0, throw a *SyntaxError* exception.
       1. Remove the final element of _bytes_.
+      1. Set _byteLength_ to _byteLength_ - 1.
     1. Let _result_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _byteLength_).
     1. Set the value at each index of _result_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _bytes_.
     1. Return _result_.

--- a/stream.mjs
+++ b/stream.mjs
@@ -1,0 +1,121 @@
+import './playground/polyfill-install.mjs';
+
+let whitespace = new Set(['\u0009', '\u000A', '\u000C', '\u000D', '\u0020']);
+
+// This mirrors the somewhat awkward TextDecoder API.
+// Better designs are of course possible.
+class Base64Decoder {
+  #options;
+  #extra;
+  constructor(options) {
+    this.#options = options;
+    this.#extra = '';
+  }
+
+  decode(chunk = '', options = {}) {
+    let stream = options.stream ?? false;
+    chunk = this.#extra + chunk;
+    this.#extra = '';
+
+    if (!stream) {
+      return Uint8Array.fromBase64(chunk, this.#options);
+    }
+
+    let realCharacterCount = 0;
+    let hasWhitespace = false;
+    for (let i = 0; i < chunk.length; ++i) {
+      if (whitespace.has(chunk[i])) {
+        hasWhitespace = true;
+      } else {
+        ++realCharacterCount;
+      }
+    }
+
+    // requires 1 additional pass over `chunk`, plus one additional copy of `chunk`
+    let extraCharacterCount = realCharacterCount % 4;
+    if (extraCharacterCount !== 0) {
+      if (!hasWhitespace) {
+        this.#extra = chunk.slice(-extraCharacterCount);
+        chunk = chunk.slice(0, -extraCharacterCount);
+      } else {
+        // need to do a bit more work to figure out where to slice
+        let collected = 0;
+        let i = chunk.length - 1;
+        while (true) {
+          if (!whitespace.has(chunk[i])) {
+            ++collected;
+            if (collected === extraCharacterCount) {
+              break;
+            }
+          }
+          --i;
+        }
+        this.#extra = chunk.slice(i);
+        chunk = chunk.slice(0, i);
+      }
+    }
+
+    return Uint8Array.fromBase64(chunk, this.#options);
+  }
+}
+
+
+class Base64Encoder {
+  #options;
+  #extra;
+  #extraLength;
+  constructor(options) {
+    this.#options = options;
+    this.#extra = new Uint8Array(3);
+    this.#extraLength = 0;
+  }
+
+  // partly derived from https://github.com/lucacasonato/base64_streams/blob/main/src/iterator/encoder.ts
+  encode(chunk = Uint8Array.of(), options = {}) {
+    let stream = options.stream ?? false;
+
+    if (this.#extraLength > 0) {
+      let bytesNeeded = 3 - this.#extraLength;
+      let bytesAvailable = Math.min(bytesNeeded, chunk.length);
+      this.#extra.set(chunk.subarray(0, bytesAvailable), this.#extraLength);
+      chunk = chunk.subarray(bytesAvailable);
+      this.#extraLength += bytesAvailable;
+    }
+
+    if (!stream) {
+      // assert: this.#extraLength.length === 0 || this.#extraLength === 3 || chunk.length === 0
+      let prefix = this.#extra.subarray(0, this.#extraLength).toBase64();
+      this.#extraLength = 0;
+      return prefix + chunk.toBase64();
+    }
+
+    let extraReturn = '';
+
+    if (this.#extraLength === 3) {
+      extraReturn = this.#extra.toBase64();
+      this.#extraLength = 0;
+    }
+
+    let remainder = chunk.length % 3;
+    if (remainder > 0) {
+      this.#extra.set(chunk.subarray(chunk.length - remainder));
+      this.#extraLength = remainder;
+      chunk = chunk.subarray(0, chunk.length - remainder);
+    }
+
+    return extraReturn + chunk.toBase64();
+  }
+}
+
+let decoder = new Base64Decoder();
+
+console.log(decoder.decode('SG  Vsb', { stream: true }));
+console.log(decoder.decode('G8gV29ybGR', { stream: true }));
+console.log(decoder.decode());
+
+
+let encoder = new Base64Encoder();
+
+console.log(encoder.encode(Uint8Array.of(72, 101, 108, 108, 111), { stream: true }));
+console.log(encoder.encode(Uint8Array.of(32, 87, 111, 114, 108, 100), { stream: true }));
+console.log(encoder.encode());

--- a/test-polyfill.mjs
+++ b/test-polyfill.mjs
@@ -49,7 +49,7 @@ let illegal = [
   'Z＋==', // U+FF0B 'Fullwidth Plus Sign'
   'Zg\u00A0==', // nbsp
   'Zg\u2009==', // thin space
-  'Zg\u2028==', // thin space
+  'Zg\u2028==', // line separator
 ];
 test('illegal characters', async t => {
   for (let string of malformedPadding) {

--- a/test-polyfill.mjs
+++ b/test-polyfill.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+import {
+  uint8ArrayToBase64,
+  base64ToUint8Array,
+  uint8ArrayToHex,
+  hexToUint8Array,
+} from './playground/polyfill-core.mjs';
+
+let stringToBytes = str => new TextEncoder().encode(str);
+
+// https://datatracker.ietf.org/doc/html/rfc4648#section-10
+let standardBase64Vectors = [
+  ['', ''],
+  ['f', 'Zg=='],
+  ['fo', 'Zm8='],
+  ['foo', 'Zm9v'],
+  ['foob', 'Zm9vYg=='],
+  ['fooba', 'Zm9vYmE='],
+  ['foobar', 'Zm9vYmFy'],
+];
+test('standard vectors', async t => {
+  for (let [string, result] of standardBase64Vectors) {
+    await t.test(JSON.stringify(string), () => {
+      assert.strictEqual(uint8ArrayToBase64(stringToBytes(string)), result);
+
+      assert.deepStrictEqual(base64ToUint8Array(result), stringToBytes(string));
+      assert.deepStrictEqual(base64ToUint8Array(result, { strict: true }), stringToBytes(string));
+    });
+  }
+});
+
+let malformedPadding = ['=', 'Zg=', 'Z===', 'Zm8==', 'Zm9v='];
+test('malformed padding', async t => {
+  for (let string of malformedPadding) {
+    await t.test(JSON.stringify(string), () => {
+      assert.throws(() => base64ToUint8Array(string), SyntaxError);
+      assert.throws(() => base64ToUint8Array(string, { strict: true }), SyntaxError);
+    });
+  }
+});
+
+let illegal = [
+  'Zm.9v',
+  'Zm9v^',
+  'Zg==&',
+  'Z−==', // U+2212 'Minus Sign'
+  'Z＋==', // U+FF0B 'Fullwidth Plus Sign'
+  'Zg\u00A0==', // nbsp
+  'Zg\u2009==', // thin space
+  'Zg\u2028==', // thin space
+];
+test('illegal characters', async t => {
+  for (let string of malformedPadding) {
+    await t.test(JSON.stringify(string), () => {
+      assert.throws(() => base64ToUint8Array(string), SyntaxError);
+      assert.throws(() => base64ToUint8Array(string, { strict: true }), SyntaxError);
+    });
+  }
+});
+
+let onlyNonStrict = [
+  ['Zg', Uint8Array.of(0x66)],
+  ['Zh', Uint8Array.of(0x66)],
+  ['Zh==', Uint8Array.of(0x66)],
+  ['Zm8', Uint8Array.of(0x66, 0x6f)],
+  ['Zm9', Uint8Array.of(0x66, 0x6f)],
+  ['Zm9=', Uint8Array.of(0x66, 0x6f)],
+];
+test('only valid in non-strict', async t => {
+  for (let [encoded, decoded] of onlyNonStrict) {
+    await t.test(JSON.stringify(encoded), () => {
+      assert.deepStrictEqual(base64ToUint8Array(encoded), decoded);
+      assert.throws(() => base64ToUint8Array(encoded, { strict: true }), SyntaxError);
+    });
+  }
+});
+
+test('alphabet-specific strings', async t => {
+  let standardOnly = 'x+/y';
+  await t.test(JSON.stringify(standardOnly), () => {
+    assert.deepStrictEqual(base64ToUint8Array(standardOnly), Uint8Array.of(0xc7, 0xef, 0xf2));
+    assert.deepStrictEqual(base64ToUint8Array(standardOnly, { alphabet: 'base64' }), Uint8Array.of(0xc7, 0xef, 0xf2));
+    assert.throws(() => base64ToUint8Array(standardOnly, { alphabet: 'base64url' }), SyntaxError);
+  });
+
+  let urlOnly = 'x-_y';
+  await t.test(JSON.stringify(urlOnly), () => {
+    assert.deepStrictEqual(base64ToUint8Array(urlOnly, { alphabet: 'base64url' }), Uint8Array.of(0xc7, 0xef, 0xf2));
+    assert.throws(() => base64ToUint8Array(urlOnly), SyntaxError);
+    assert.throws(() => base64ToUint8Array(urlOnly, { alphabet: 'base64' }), SyntaxError);
+  });
+});


### PR DESCRIPTION
This removes the streaming API per https://github.com/tc39/proposal-arraybuffer-base64/issues/13#issuecomment-1738345569.

I've also filled out the details of the spec text; documented base64 variations in the RFCs, in other languages, and in existing base64 libraries; settled all the outstanding questions about the API; and updated the polyfill and added tests for it.

cc @phoddie