### PR TITLE
allow writing to an existing Uint8Array, and add lastChunkHandling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ assert.deepStrictEqual([...target], [102, 111, 111, 98, 97, 114, 0, 0]);
 assert.deepStrictEqual({ read, written }, { read: 8, written: 6 });
 ```
 
-This method takes an optional final options bag with the same options as above, plus an `outputOffset` option which allows specifying a position in the target array to write to without needing to create a subarray.
+This method takes an optional final options bag with the same options as above.
+
+As with `encodeInto`, there is not explicit support for writing to specified offset of the target, but you can accomplish that by creating a subarray.
 
 `Uint8Array.fromHexInto` is the same except for hex.
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,34 @@ console.log(Uint8Array.fromHex(string));
 
 This would add `Uint8Array.prototype.toBase64`/`Uint8Array.prototype.toHex` and `Uint8Array.fromBase64`/`Uint8Array.fromHex` methods. The latter pair would throw if given a string which is not properly encoded.
 
-## Options
+## Base64 options
 
-An options bag argument for the base64 methods allows specifying the alphabet as either `base64` or `base64url`.
+Additional options are supplied in an options bag argument:
 
-When decoding, the options bag also allows specifying `strict: false` (the default) or `strict: true`. When using `strict: false`, whitespace is legal and padding is optional. When using `strict: true`, whitespace is forbidden and standard padding (including any overflow bits in the last character being 0) is enforced - i.e., only [canonical](https://datatracker.ietf.org/doc/html/rfc4648#section-3.5) encodings are allowed.
+- `alphabet`: Allows specifying the alphabet as either `base64` or `base64url`.
+
+- `lastChunkHandling`: Recall that base64 decoding operates on chunks of 4 characters at a time, but the input maybe have some characters which don't fit evenly into such a chunk of 4 characters. This option determines how the final chunk of characters should be handled. The three options are `"loose"` (the default), which treats the chunk as if it had any necessary `=` padding (but throws if this is not possible, i.e. there is exactly one extra character); `"strict"`, which enforces that the chunk has exactly 4 characters (counting `=` padding) and that [overflow bits](https://datatracker.ietf.org/doc/html/rfc4648#section-3.5) are 0; and `"stop-before-partial"`, which stops decoding before the final chunk unless the final chunk has exactly 4 characters.
+
+The hex methods do not take any options.
+
+## Writing to an existing Uint8Array
+
+The `Uint8Array.fromBase64Into` method allows writing to an existing Uint8Array. Like the [TextEncoder `encodeInto` method](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encodeInto), it returns a `{ read, written }` pair.
+
+```js
+let target = new Uint8Array(8);
+let { read, written } = Uint8Array.fromBase64Into('Zm9vYmFy', target);
+assert.deepStrictEqual([...target], [102, 111, 111, 98, 97, 114, 0, 0]);
+assert.deepStrictEqual({ read, written }, { read: 8, written: 6 });
+```
+
+This method takes an optional final options bag with the same options as above, plus an `outputOffset` option which allows specifying a position in the target array to write to without needing to create a subarray.
+
+`Uint8Array.fromHexInto` is the same except for hex.
 
 ## Streaming
 
-There is no support for streaming. However, it is [relatively straightforward to do effeciently in userland](./stream.mjs) on top of this API, with support for all the same options as the underlying functions.
+There is no explicit support for streaming. However, it is [relatively straightforward to do effeciently in userland](./stream.mjs) on top of this API, with support for all the same options as the underlying functions.
 
 ## FAQ
 
@@ -68,17 +87,17 @@ For hex, both lowercase and uppercase characters (including mixed within the sam
 
 ### How is `=` padding handled?
 
-Padding is always generated. The base64 decoder does not require it to be present unless `strict: true` is specified; however, if it is present, it must be well-formed (i.e., once stripped of whitespace the length of the string must be a multiple of 4, and there can be 1 or 2 padding `=` characters).
+Padding is always generated. The base64 decoder allows specifying how to handle inputs without it with the `lastChunkHandling` option.
 
 ### How are the extra padding bits handled?
 
 If the length of your input data isn't exactly a multiple of 3 bytes, then encoding it will use either 2 or 3 base64 characters to encode the final 1 or 2 bytes. Since each base64 character is 6 bits, this means you'll be using either 12 or 18 bits to represent 8 or 16 bits, which means you have an extra 4 or 2 bits which don't encode anything.
 
-Per [the RFC](https://datatracker.ietf.org/doc/html/rfc4648#section-3.5), decoders MAY reject input strings where the padding bits are non-zero. Here, non-zero padding bits are silently ignored when `strict: false` (the default), and are an error when `strict: true`.
+Per [the RFC](https://datatracker.ietf.org/doc/html/rfc4648#section-3.5), decoders MAY reject input strings where the padding bits are non-zero. Here, non-zero padding bits are silently ignored unless `lastChunkHandling: "strict"` is specified.
 
 ### How is whitespace handled?
 
-The encoders do not output whitespace. The hex decoder does not allow it as input. The base64 decoder allows [ASCII whitespace](https://infra.spec.whatwg.org/#ascii-whitespace) anywhere in the string as long as `strict: true` is not specified.
+The encoders do not output whitespace. The hex decoder does not allow it as input. The base64 decoder allows [ASCII whitespace](https://infra.spec.whatwg.org/#ascii-whitespace) anywhere in the string.
 
 ### How are other characters handled?
 
@@ -107,7 +126,3 @@ That's also been the consensus when it's come up [previously](https://discourse.
 ### What if I just want to encode a portion of an ArrayBuffer?
 
 Uint8Arrays can be partial views of an underlying buffer, so you can create such a view and invoke `.toBase64` on it.
-
-### What if I want to decode a Base64 or hex string into an existing Typed Array or ArrayBuffer?
-
-While that is a reasonable things to want, I think it need not be included in the initial version of this API. We can add it later if demand proves high. Until then, copying slices of memory (e.g. using `target.set(chunk, offset)`) is quite fast.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "proposal-arraybuffer-base64",
       "dependencies": {
-        "@tc39/ecma262-biblio": "2.1.2653",
+        "@tc39/ecma262-biblio": "^2.1.2663",
         "ecmarkup": "^18.0.0",
         "jsdom": "^21.1.1",
         "prismjs": "^1.29.0"
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "2.1.2653",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2653.tgz",
-      "integrity": "sha512-/CIVRwkV3fTaYNxFSEvbDsTPFBNfeJOjQACZXs11+NKkbHhFh9pvr8j6NbJ/fekJLgAu6x2QXvGdA/kEGR/08g=="
+      "version": "2.1.2663",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2663.tgz",
+      "integrity": "sha512-CZgOFz73hKQVXFLPpaFfMNRVx+xQxXnUlQEC8Nde/r4W2g9e1c0C8gzxAZOP+v8IQLFn09xXnVz/GN9Ry3YN1w=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "name": "proposal-arraybuffer-base64",
   "scripts": {
     "build-playground": "mkdir -p dist && cp playground/* dist && node scripts/static-highlight.js playground/index-raw.html > dist/index.html && rm dist/index-raw.html",
-    "build-spec": "mkdir -p dist/spec && ecmarkup --lint-spec --strict --load-biblio @tc39/ecma262-biblio --verbose spec.html --assets-dir dist/spec dist/spec/index.html",
+    "build-spec": "mkdir -p dist/spec && ecmarkup --lint-spec --strict --load-biblio @tc39/ecma262-biblio --verbose --mark-effects spec.html --assets-dir dist/spec dist/spec/index.html",
     "build": "npm run build-playground && npm run build-spec",
     "format": "emu-format --write spec.html",
     "check-format": "emu-format --check spec.html"
   },
   "dependencies": {
-    "@tc39/ecma262-biblio": "2.1.2653",
+    "@tc39/ecma262-biblio": "^2.1.2663",
     "ecmarkup": "^18.0.0",
     "jsdom": "^21.1.1",
     "prismjs": "^1.29.0"

--- a/playground/index-raw.html
+++ b/playground/index-raw.html
@@ -10,6 +10,7 @@
 <script>
 // logic for making codeblocks copyable
 // svg from https://feathericons.com/
+'use strict';
 let copySVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="feather feather-copy"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
 
 if (navigator.clipboard) {
@@ -84,8 +85,8 @@ console.log(Uint8Array.fromHex(string));
 </code></pre>
 
 <h3>Options</h3>
-<p>The base64 methods take an optional options bag which allows specifying the alphabet as either "base64" (the default) or "base64url" (<a href="https://datatracker.ietf.org/doc/html/rfc4648#section-5">the URL-safe variant</a>).</p>
-<p>When encoding, the options bag also allows specifying <code>strict: false</code> (the default) or <code>strict: true</code>. When using <code>strict: false</code>, whitespace is legal and padding is optional. When using <code>strict: true</code>, whitespace is forbidden and standard padding (including any overflow bits in the last character being 0) is enforced - i.e., only <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-3.5">canonical</a> encodings are allowed.</p>
+<p>The base64 methods take an optional options bag which allows specifying the alphabet as either <code>"base64"</code> (the default) or <code>"base64url"</code> (<a href="https://datatracker.ietf.org/doc/html/rfc4648#section-5">the URL-safe variant</a>).</p>
+<p>The base64 decoder also allows specifying the behavior for the final chunk with <code>lastChunkHandling</code>. Recall that base64 decoding operates on chunks of 4 characters at a time, but the input maybe have some characters which don't fit evenly into such a chunk of 4 characters. This option determines how the final chunk of characters should be handled. The three options are <code>"loose"</code> (the default), which treats the chunk as if it had any necessary <code>=</code> padding (but throws if this is not possible, i.e. there is exactly one extra character); <code>"strict"</code>, which enforces that the chunk has exactly 4 characters (counting <code>=</code> padding) and that <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-3.5">overflow bits</a> are 0; and <code>"stop-before-partial"</code>, which stops decoding before the final chunk unless the final chunk has exactly 4 characters.
 <p>The hex methods do not have any options.</p>
 
 <pre class="language-js"><code class="language-js">
@@ -99,20 +100,36 @@ console.log(Uint8Array.fromBase64('SGVsbG8g\nV29ybG R'));
 // works, despite whitespace, missing padding, and non-zero overflow bits
 
 try {
-  Uint8Array.fromBase64('SGVsbG8g\nV29ybG Q=', { strict: true });
+  Uint8Array.fromBase64('SGVsbG8gV29ybGR=', { lastChunkHandling: 'strict' });
 } catch {
-  console.log('with strict: true, whitespace is rejected');
+  console.log('with lastChunkHandling: "strict", overflow bits are rejected');
 }
 try {
-  Uint8Array.fromBase64('SGVsbG8gV29ybGQ', { strict: true });
+  Uint8Array.fromBase64('SGVsbG8gV29ybGQ', { lastChunkHandling: 'strict' });
 } catch {
-  console.log('with strict: true, padding is required');
+  console.log('with lastChunkHandling: "strict", overflow bits are rejected');
 }
-try {
-  Uint8Array.fromBase64('SGVsbG8gV29ybGR=', { strict: true });
-} catch {
-  console.log('with strict: true, non-zero overflow bits are rejected');
-}
+</code></pre>
+
+<h3>Writing to an existing Uint8Array</h3>
+<p>The <code>Uint8Array.fromBase64Into</code> method allows writing to an existing Uint8Array. Like the <a href="https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encodeInto">TextEncoder <code>encodeInto</code> method</a>, it returns a <code>{ read, written }</code> pair.</p>
+
+<p>This method takes an optional final options bag with the same options as above, plus an <code>outputOffset</code> option which allows specifying a position in the target array to write to without needing to create a subarray.</p>
+
+<pre class="language-js"><code class="language-js">
+let target = new Uint8Array(7);
+let { read, written } = Uint8Array.fromBase64Into('Zm9vYmFy', target);
+console.log({ target, read, written });
+// { target: Uint8Array([102, 111, 111, 98, 97, 114, 0]), read: 8, written: 6 }
+</code></pre>
+
+<p><code>Uint8Array.fromHexInto</code> is the same except for hex.</p>
+
+<pre class="language-js"><code class="language-js">
+let target = new Uint8Array(6);
+let { read, written } = Uint8Array.fromHexInto('deadbeef', target);
+console.log({ target, read, written });
+// { target: Uint8Array([222, 173, 190, 239, 0, 0]), read: 8, written: 4 }
 </code></pre>
 
 <h3>Streaming</h3>

--- a/playground/index-raw.html
+++ b/playground/index-raw.html
@@ -114,7 +114,7 @@ try {
 <h3>Writing to an existing Uint8Array</h3>
 <p>The <code>Uint8Array.fromBase64Into</code> method allows writing to an existing Uint8Array. Like the <a href="https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encodeInto">TextEncoder <code>encodeInto</code> method</a>, it returns a <code>{ read, written }</code> pair.</p>
 
-<p>This method takes an optional final options bag with the same options as above, plus an <code>outputOffset</code> option which allows specifying a position in the target array to write to without needing to create a subarray.</p>
+<p>This method takes an optional final options bag with the same options as above.</p>
 
 <pre class="language-js"><code class="language-js">
 let target = new Uint8Array(7);

--- a/playground/polyfill-core.mjs
+++ b/playground/polyfill-core.mjs
@@ -213,25 +213,15 @@ export function base64ToUint8Array(string, options, into) {
   if (!['loose', 'strict', 'stop-before-partial'].includes(lastChunkHandling)) {
     throw new TypeError('expected lastChunkHandling to be either "loose", "strict", or "stop-before-partial"');
   }
-  let outputOffset = 0;
-  if (into) {
-    outputOffset = opts.outputOffset;
-    if (typeof outputOffset === 'undefined') {
-      outputOffset = 0;
-    } else if (typeof outputOffset !== 'number' || Math.round(outputOffset) !== outputOffset || outputOffset < 0 || outputOffset >= into.length) {
-      // TODO: do we want to accept negative wrap-around offsets? probably?
-      throw new RangeError('outputOffset must be an integer between 0 and into.length');
-    }
-  }
 
-  let maxLength = into ? (into.length - outputOffset) : 2 ** 53 - 1;
+  let maxLength = into ? into.length : 2 ** 53 - 1;
 
   let { bytes, read } = fromBase64(string, alphabet, lastChunkHandling, maxLength);
 
   bytes = new Uint8Array(bytes);
   if (into) {
-    assert(bytes.length <= into.length - outputOffset);
-    into.set(bytes, outputOffset);
+    assert(bytes.length <= into.length);
+    into.set(bytes);
   }
 
   return { read, bytes };
@@ -246,7 +236,7 @@ export function uint8ArrayToHex(arr) {
   return out;
 }
 
-export function hexToUint8Array(string, options, into) {
+export function hexToUint8Array(string, into) {
   if (typeof string !== 'string') {
     throw new TypeError('expected string to be a string');
   }
@@ -257,18 +247,7 @@ export function hexToUint8Array(string, options, into) {
     throw new SyntaxError('string should only contain hex characters');
   }
 
-  let outputOffset = 0;
-  if (into) {
-    let opts = getOptions(options);
-    outputOffset = opts.outputOffset;
-    if (typeof outputOffset === 'undefined') {
-      outputOffset = 0;
-    } else if (typeof outputOffset !== 'number' || Math.round(number) !== number || number < 0 || number >= into.length) {
-      // TODO: do we want to accept negative wrap-around offsets? probably?
-      throw new RangeError('outputOffset must be an integer between 0 and into.length');
-    }
-  }
-  let maxLength = into ? (into.length - outputOffset) : 2 ** 53 - 1;
+  let maxLength = into ? into.length : 2 ** 53 - 1;
 
   // TODO should hex allow whitespace?
   // TODO should hex support lastChunkHandling? (only 'strict' or 'stop-before-partial')
@@ -286,8 +265,8 @@ export function hexToUint8Array(string, options, into) {
 
   bytes = new Uint8Array(bytes);
   if (into) {
-    assert(bytes.length <= into.length - outputOffset);
-    into.set(bytes, outputOffset);
+    assert(bytes.length <= into.length);
+    into.set(bytes);
   }
 
   return { read: index, bytes };

--- a/playground/polyfill-install.mjs
+++ b/playground/polyfill-install.mjs
@@ -1,11 +1,23 @@
-import { uint8ArrayToBase64, base64ToUint8Array, uint8ArrayToHex, hexToUint8Array } from './polyfill-core.mjs';
+import { uint8ArrayToBase64, base64ToUint8Array, uint8ArrayToHex, hexToUint8Array, checkUint8Array } from './polyfill-core.mjs';
 
 Uint8Array.prototype.toBase64 = function (options) {
   return uint8ArrayToBase64(this, options);
 };
 
 Uint8Array.fromBase64 = function (string, options) {
-  return base64ToUint8Array(string, options);
+  if (typeof string !== 'string') {
+    throw new TypeError('expected input to be a string');
+  }
+  return base64ToUint8Array(string, options).bytes;
+};
+
+Uint8Array.fromBase64Into = function (string, into, options) {
+  if (typeof string !== 'string') {
+    throw new TypeError('expected input to be a string');
+  }
+  checkUint8Array(into);
+  let { read, bytes } = base64ToUint8Array(string, options, into);
+  return { read, written: bytes.length };
 };
 
 Uint8Array.prototype.toHex = function () {
@@ -13,5 +25,17 @@ Uint8Array.prototype.toHex = function () {
 };
 
 Uint8Array.fromHex = function (string) {
-  return hexToUint8Array(string);
+  if (typeof string !== 'string') {
+    throw new TypeError('expected input to be a string');
+  }
+  return hexToUint8Array(string).bytes;
+};
+
+Uint8Array.fromHexInto = function (string, into, options) {
+  if (typeof string !== 'string') {
+    throw new TypeError('expected input to be a string');
+  }
+  checkUint8Array(into);
+  let { read, bytes } = hexToUint8Array(string, options, into);
+  return { read, written: bytes.length };
 };

--- a/playground/polyfill-install.mjs
+++ b/playground/polyfill-install.mjs
@@ -31,11 +31,11 @@ Uint8Array.fromHex = function (string) {
   return hexToUint8Array(string).bytes;
 };
 
-Uint8Array.fromHexInto = function (string, into, options) {
+Uint8Array.fromHexInto = function (string, into) {
   if (typeof string !== 'string') {
     throw new TypeError('expected input to be a string');
   }
   checkUint8Array(into);
-  let { read, bytes } = hexToUint8Array(string, options, into);
+  let { read, bytes } = hexToUint8Array(string, into);
   return { read, written: bytes.length };
 };

--- a/spec.html
+++ b/spec.html
@@ -81,21 +81,15 @@ contributors: Kevin Gibbons
     1. Let _lastChunkHandling_ be ? Get(_opts_, *"lastChunkHandling"*).
     1. If _lastChunkHandling_ is *undefined*, set _lastChunkHandling_ to *"loose"*.
     1. If _lastChunkHandling_ is not one of *"loose"*, *"strict"*, or *"stop-before-partial"*, throw a *TypeError* exception.
-    1. Let _outputOffset_ be ? Get(_opts_, *"outputOffset"*).
-    1. If _outputOffset_ is *undefined*, set _outputOffset_ to *+0*<sub>𝔽</sub>.
-    1. If _outputOffset_ is not an integral Number, throw a *RangeError* exception.
-    1. Set _outputOffset_ to ℝ(_outputOffset_).
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
     1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
-    1. If _outputOffset_ < 0 or _outputOffset_ ≥ _byteLength_, then
-      1. Throw a *RangeError* exception.
-    1. Let _maxLength_ be _byteLength_ - _outputOffset_.
+    1. Let _maxLength_ be _byteLength_.
     1. Let _result_ be ? FromBase64(_string_, _alphabet_, _lastChunkHandling_, _maxLength_).
     1. Let _bytes_ be _result_.[[Bytes]].
     1. Let _written_ be the length of _bytes_.
     1. NOTE: FromBase64 does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
     1. Assert: _written_ ≤ _byteLength_.
-    1. Let _offset_ be _into_.[[ByteOffset]] + _outputOffset_.
+    1. Let _offset_ be _into_.[[ByteOffset]].
     1. Let _index_ be 0.
     1. Repeat, while _index_ < _written_,
       1. Let _byte_ be _bytes_[i].
@@ -121,27 +115,20 @@ contributors: Kevin Gibbons
 </emu-clause>
 
 <emu-clause id="sec-uint8array.fromhexinto">
-  <h1>Uint8Array.fromHexInto ( _string_, _into_ [ , _options_ ] )</h1>
+  <h1>Uint8Array.fromHexInto ( _string_, _into_ )</h1>
   <emu-alg>
     1. If _string_ is not a String, throw a *TypeError* exception.
     1. Perform ? RequireInternalSlot(_into_, [[TypedArrayName]]).
     1. If _into_.[[TypedArrayName]] is not *"Uint8Array"*, throw a *TypeError* exception.
-    1. Let _opts_ be ? GetOptionsObject(_options_).
-    1. Let _outputOffset_ be ? Get(_opts_, *"outputOffset"*).
-    1. If _outputOffset_ is *undefined*, set _outputOffset_ to *+0*<sub>𝔽</sub>.
-    1. If _outputOffset_ is not an integral Number, throw a *RangeError* exception.
-    1. Set _outputOffset_ to ℝ(_outputOffset_).
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
     1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
-    1. If _outputOffset_ < 0 or _outputOffset_ ≥ _byteLength_, then
-      1. Throw a *RangeError* exception.
-    1. Let _maxLength_ be _byteLength_ - _outputOffset_.
+    1. Let _maxLength_ be _byteLength_.
     1. Let _result_ be ? FromHex(_string_, _maxLength_).
     1. Let _bytes_ be _result_.[[Bytes]].
     1. Let _written_ be the length of _bytes_.
     1. NOTE: FromHex does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
     1. Assert: _written_ ≤ _byteLength_.
-    1. Let _offset_ be _into_.[[ByteOffset]] + _outputOffset_.
+    1. Let _offset_ be _into_.[[ByteOffset]].
     1. Let _index_ be 0.
     1. Repeat, while _index_ < _written_,
       1. Let _byte_ be _bytes_[i].

--- a/spec.html
+++ b/spec.html
@@ -49,7 +49,6 @@ contributors: Kevin Gibbons
 
 <emu-clause id="sec-uint8array.frombase64">
   <h1>Uint8Array.fromBase64 ( _string_ [ , _options_ ] )</h1>
-  <p>The <dfn id="standard-base64-alphabet">standard base64 alphabet</dfn> is a List whose elements are the code points corresponding to every letter and number in the Unicode Basic Latin block along with *"+"* and *"/"*; that is, it is StringToCodePoints(*"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"*).</p>
   <emu-alg>
     1. If _string_ is not a String, throw a *TypeError* exception.
     1. Let _opts_ be ? GetOptionsObject(_options_).
@@ -57,50 +56,55 @@ contributors: Kevin Gibbons
     1. If _alphabet_ is *undefined*, set _alphabet_ to *"base64"*.
     1. If _alphabet_ is not a String, throw a *TypeError* exception.
     1. If _alphabet_ is neither *"base64"* nor *"base64url"*, throw a *TypeError* exception.
-    1. Let _strict_ be ToBoolean(? Get(_opts_, *"strict"*)).
-    1. NOTE: The order of validation and decoding in the algorithm below is not observable. Implementations are encouraged to perform them in whatever order is most efficient, possibly interleaving validation and stripping whitespace with decoding, as long as the behaviour is observably equivalent.
-    1. Let _input_ be StringToCodePoints(_string_).
-    1. If _alphabet_ is *"base64url"*, then
-      1. If _input_ contains U+002B (PLUS SIGN) or U+002F (SOLIDUS), throw a *SyntaxError* exception.
-      1. Replace all occurrences of U+002D (HYPHEN-MINUS) in _input_ with U+002B (PLUS SIGN).
-      1. Replace all occurrences of U+005F (LOW LINE) in _input_ with U+002F (SOLIDUS).
-    1. NOTE: When _strict_ is *false*, the algorithm below is equivalent to the <a href="https://infra.spec.whatwg.org/#forgiving-base64-decode">forgiving-base64 decode</a> operation in HTML.
-    1. If _strict_ is *false*, then
-      1. Remove all occurrences of U+0009 (TAB), U+000A (LF), U+000C (FF), U+000D (CR), and U+0020 (SPACE) from _input_.
-    1. Let _inputLength_ be the length of _input_.
-    1. If _inputLength_ modulo 4 is 0, then
-      1. If _input_ is not empty and the last element of _input_ is U+003D (EQUALS SIGN), then
-        1. Remove the last element of _input_.
-        1. Set _inputLength_ to _inputLength_ - 1.
-        1. If _input_ is not empty and the last element of _input_ is U+003D (EQUALS SIGN), then
-          1. Remove the last element of _input_.
-          1. Set _inputLength_ to _inputLength_ - 1.
-    1. Else,
-      1. If _strict_ is *true*, throw a *SyntaxError* exception.
-    1. If _input_ contains any elements which are not also elements of the standard base64 alphabet, throw a *SyntaxError* exception.
-    1. Let _lastChunkSize_ be _inputLength_ modulo 4.
-    1. If _lastChunkSize_ is 1, then
-      1. Throw a *SyntaxError* exception.
-    1. Else if _lastChunkSize_ is 2, then
-      1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_ twice.
-    1. Else if _lastChunkSize_ is 3, then
-      1. Append U+0041 (LATIN CAPITAL LETTER A) to _input_.
-    1. Assert: The length of _input_ is now a multiple of 4.
-    1. Let _bytes_ be the unique (possibly empty) sequence of bytes resulting from decoding _input_ as base64 (such that applying the base64 encoding specified in section 4 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a> to _bytes_ would produce _input_).
-    1. Let _byteLength_ be the length of _bytes_.
-    1. If _lastChunkSize_ is 2, then
-      1. Assert: _byteLength_ ≥ 3.
-      1. If _strict_ is *true* and _bytes_[_byteLength_ - 2] is not 0, throw a *SyntaxError* exception.
-      1. Remove the final 2 elements of _bytes_.
-      1. Set _byteLength_ to _byteLength_ - 2.
-    1. Else if _lastChunkSize_ is 3, then
-      1. Assert: _byteLength_ ≥ 3.
-      1. If _strict_ is *true* and _bytes_[_byteLength_ - 1] is not 0, throw a *SyntaxError* exception.
-      1. Remove the final element of _bytes_.
-      1. Set _byteLength_ to _byteLength_ - 1.
-    1. Let _result_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _byteLength_).
-    1. Set the value at each index of _result_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _bytes_.
-    1. Return _result_.
+    1. Let _lastChunkHandling_ be ? Get(_opts_, *"lastChunkHandling"*).
+    1. If _lastChunkHandling_ is *undefined*, set _lastChunkHandling_ to *"loose"*.
+    1. If _lastChunkHandling_ is not one of *"loose"*, *"strict"*, or *"stop-before-partial"*, throw a *TypeError* exception.
+    1. Let _result_ be ? FromBase64(_string_, _alphabet_, _lastChunkHandling_).
+    1. Let _resultLength_ be the length of _result_.[[Bytes]].
+    1. Let _ta_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _resultLength_).
+    1. Set the value at each index of _ta_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _ta_.[[Bytes]].
+    1. Return _ta_.
+  </emu-alg>
+</emu-clause>
+
+<emu-clause id="sec-uint8array.frombase64into">
+  <h1>Uint8Array.fromBase64Into ( _string_, _into_ [ , _options_ ] )</h1>
+  <emu-alg>
+    1. If _string_ is not a String, throw a *TypeError* exception.
+    1. Perform ? RequireInternalSlot(_into_, [[TypedArrayName]]).
+    1. If _into_.[[TypedArrayName]] is not *"Uint8Array"*, throw a *TypeError* exception.
+    1. Let _opts_ be ? GetOptionsObject(_options_).
+    1. Let _alphabet_ be ? Get(_opts_, *"alphabet"*).
+    1. If _alphabet_ is *undefined*, set _alphabet_ to *"base64"*.
+    1. If _alphabet_ is not a String, throw a *TypeError* exception.
+    1. If _alphabet_ is neither *"base64"* nor *"base64url"*, throw a *TypeError* exception.
+    1. Let _lastChunkHandling_ be ? Get(_opts_, *"lastChunkHandling"*).
+    1. If _lastChunkHandling_ is *undefined*, set _lastChunkHandling_ to *"loose"*.
+    1. If _lastChunkHandling_ is not one of *"loose"*, *"strict"*, or *"stop-before-partial"*, throw a *TypeError* exception.
+    1. Let _outputOffset_ be ? Get(_opts_, *"outputOffset"*).
+    1. If _outputOffset_ is *undefined*, set _outputOffset_ to *+0*<sub>𝔽</sub>.
+    1. If _outputOffset_ is not an integral Number, throw a *RangeError* exception.
+    1. Set _outputOffset_ to ℝ(_outputOffset_).
+    1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
+    1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
+    1. If _outputOffset_ < 0 or _outputOffset_ ≥ _byteLength_, then
+      1. Throw a *RangeError* exception.
+    1. Let _maxLength_ be _byteLength_ - _outputOffset_.
+    1. Let _result_ be ? FromBase64(_string_, _alphabet_, _lastChunkHandling_, _maxLength_).
+    1. Let _bytes_ be _result_.[[Bytes]].
+    1. Let _written_ be the length of _bytes_.
+    1. NOTE: FromBase64 does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
+    1. Assert: _written_ ≤ _byteLength_.
+    1. Let _offset_ be _into_.[[ByteOffset]] + _outputOffset_.
+    1. Let _index_ be 0.
+    1. Repeat, while _index_ < _written_,
+      1. Let _byte_ be _bytes_[i].
+      1. Let _byteIndexInBuffer_ be _index_ + _offset_.
+      1. Perform SetValueInBuffer(_into_.[[ViewedArrayBuffer]], _byteIndexInBuffer_, ~uint8~, 𝔽(_byte_), *true*, ~unordered~).
+    1. Let _resultObject_ be OrdinaryObjectCreate(%Object.prototype%).
+    1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"read"*, _result_.[[Read]]).
+    1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"written"*, _written_).
+    1. Return _resultObject_.
   </emu-alg>
 </emu-clause>
 
@@ -108,20 +112,45 @@ contributors: Kevin Gibbons
   <h1>Uint8Array.fromHex ( _string_ )</h1>
   <emu-alg>
     1. If _string_ is not a String, throw a *TypeError* exception.
-    1. TODO: consider stripping whitespace here.
-    1. Let _stringLen_ be the length of _string_.
-    1. If _stringLen_ modulo 2 is not 0, throw a *SyntaxError* exception.
-    1. If _string_ contains any code units which are not in *"0123456789abcdefABCDEF"*, throw a *SyntaxError* exception.
-    1. Let _resultLength_ be _stringLen_ / 2.
-    1. Let _result_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _resultLength_).
+    1. Let _result_ be ? FromHex(_string_).
+    1. Let _resultLength_ be the length of _result_.[[Bytes]].
+    1. Let _ta_ be ? AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, %Uint8Array.prototype%, _resultLength_).
+    1. Set the value at each index of _ta_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _ta_.[[Bytes]].
+    1. Return _ta_.
+  </emu-alg>
+</emu-clause>
+
+<emu-clause id="sec-uint8array.fromhexinto">
+  <h1>Uint8Array.fromHexInto ( _string_, _into_ [ , _options_ ] )</h1>
+  <emu-alg>
+    1. If _string_ is not a String, throw a *TypeError* exception.
+    1. Perform ? RequireInternalSlot(_into_, [[TypedArrayName]]).
+    1. If _into_.[[TypedArrayName]] is not *"Uint8Array"*, throw a *TypeError* exception.
+    1. Let _opts_ be ? GetOptionsObject(_options_).
+    1. Let _outputOffset_ be ? Get(_opts_, *"outputOffset"*).
+    1. If _outputOffset_ is *undefined*, set _outputOffset_ to *+0*<sub>𝔽</sub>.
+    1. If _outputOffset_ is not an integral Number, throw a *RangeError* exception.
+    1. Set _outputOffset_ to ℝ(_outputOffset_).
+    1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
+    1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
+    1. If _outputOffset_ < 0 or _outputOffset_ ≥ _byteLength_, then
+      1. Throw a *RangeError* exception.
+    1. Let _maxLength_ be _byteLength_ - _outputOffset_.
+    1. Let _result_ be ? FromHex(_string_, _maxLength_).
+    1. Let _bytes_ be _result_.[[Bytes]].
+    1. Let _written_ be the length of _bytes_.
+    1. NOTE: FromHex does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
+    1. Assert: _written_ ≤ _byteLength_.
+    1. Let _offset_ be _into_.[[ByteOffset]] + _outputOffset_.
     1. Let _index_ be 0.
-    1. Repeat, while _index_ &lt; _resultLength_,
-      1. Let _stringIndex_ be _index_ * 2.
-      1. Let _hexits_ be the substring of _string_ from _stringIndex_ to _stringIndex_ + 2.
-      1. Let _byte_ be the integer value represented by _hexits_ in base-16 notation, using the letters A-F and a-f for digits with values 10 through 15.
-      1. Perform ! IntegerIndexedElementSet(_result_, 𝔽(_index_), 𝔽(_byte_)).
-      1. Set _index_ to _index_ + 1.
-    1. Return _result_.
+    1. Repeat, while _index_ < _written_,
+      1. Let _byte_ be _bytes_[i].
+      1. Let _byteIndexInBuffer_ be _index_ + _offset_.
+      1. Perform SetValueInBuffer(_into_.[[ViewedArrayBuffer]], _byteIndexInBuffer_, ~uint8~, 𝔽(_byte_), *true*, ~unordered~).
+    1. Let _resultObject_ be OrdinaryObjectCreate(%Object.prototype%).
+    1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"read"*, _result_.[[Read]]).
+    1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"written"*, _written_).
+    1. Return _resultObject_.
   </emu-alg>
 </emu-clause>
 
@@ -144,17 +173,184 @@ contributors: Kevin Gibbons
   </emu-alg>
 </emu-clause>
 
-<!-- Copied from ECMA-402/Temporal -->
+<emu-clause id="sec-helpers">
+  <h1>Helpers</h1>
 
-<emu-clause id="sec-getoptionsobject" aoid="GetOptionsObject">
-  <h1>GetOptionsObject ( _options_ )</h1>
-  <emu-alg>
-    1. If _options_ is *undefined*, then
-      1. Return OrdinaryObjectCreate(*null*).
-    1. If Type(_options_) is Object, then
-      1. Return _options_.
-    1. Throw a *TypeError* exception.
-  </emu-alg>
+  <emu-clause id="sec-skipasciiwhitespace" type="abstract operation">
+    <h1>
+      SkipAsciiWhitespace (
+        _string_: a string,
+        _index_: a non-negative integer,
+      )
+    </h1>
+    <dl class="header">
+    </dl>
+    <emu-alg>
+      1. Let _length_ be the length of _string_.
+      1. Repeat, while _index_ < _length_,
+        1. Let _char_ be the code unit at index _index_ of _string_.
+        1. TODO: fix types - code unit vs point.
+        1. If _char_ is neither U+0009 (TAB), U+000A (LF), U+000C (FF), U+000D (CR), nor U+0020 (SPACE), then
+          1. Return _index_.
+        1. Set _index_ to _index_ + 1.
+      1. Return _index_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-decodebase64chunk" type="abstract operation">
+    <h1>
+      DecodeBase64Chunk (
+        _chunk_: a string,
+        _alphabet_: *"base64"* or *"base64url"*,
+        optional _throwOnExtraBits_: a boolean,
+      ): either a normal completion containing a List of byte values, or a throw completion
+    </h1>
+    <dl class="header">
+    </dl>
+    <p>The <dfn id="standard-base64-alphabet">standard base64 alphabet</dfn> is a List whose elements are the code points corresponding to every letter and number in the Unicode Basic Latin block along with *"+"* and *"/"*; that is, it is StringToCodePoints(*"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"*).</p>
+    <emu-alg>
+      1. Let _chunkLength_ be the length of _chunk_.
+      1. If _chunkLength_ is 2, then
+        1. Set _chunk_ to the string-concatenation of _chunk_ and *"AA"*.
+      1. Else if _chunkLength_ is 3, then
+        1. Set _chunk_ to the string-concatenation of _chunk_ and *"A"*.
+      1. Else,
+        1. Assert: _chunkLength_ is 4.
+      1. If _alphabet_ is *"base64url"*, then
+        1. TODO fix the types here - these are code points, not code units.
+        1. If _chunk_ contains U+002B (PLUS SIGN) or U+002F (SOLIDUS), throw a *SyntaxError* exception.
+        1. Replace all occurrences of U+002D (HYPHEN-MINUS) in _chunk_ with U+002B (PLUS SIGN).
+        1. Replace all occurrences of U+005F (LOW LINE) in _chunk_ with U+002F (SOLIDUS).
+      1. If any element of _chunk_ is not an element of the standard base64 alphabet, throw a *SyntaxError* exception.
+      1. Let _byteSequence_ be the unique sequence of 3 bytes resulting from decoding _chunk_ as base64 (such that applying the base64 encoding specified in section 4 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a> to _byteSequence_ would produce _chunk_).
+      1. Let _bytes_ be a List whose elements are the elements of _byteSequence_, in order.
+      1. If _chunkLength_ is 2, then
+        1. Assert: _throwOnExtraBits_ is present.
+        1. If _throwOnExtraBits_ is *true* and _bytes_[1] ≠ 0, then
+          1. Throw a *SyntaxError* exception.
+        1. Return « _bytes_[0] ».
+      1. Else if _chunkLength_ is 3, then
+        1. Assert: _throwOnExtraBits_ is present.
+        1. If _throwOnExtraBits_ is *true* and _bytes_[2] ≠ 0, then
+          1. Throw a *SyntaxError* exception.
+        1. Return « _bytes_[0], _bytes_[1] ».
+      1. Else,
+        1. Return _bytes_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-frombase64" type="abstract operation">
+    <h1>
+      FromBase64 (
+        _string_: a string,
+        _alphabet_: *"base64"* or *"base64url"*,
+        _lastChunkHandling_: *"loose"*, *"strict"*, or *"stop-before-partial"*,
+        optional _maxLength_: a non-negative integer,
+      ): either a normal completion containing a Record with fields [[Read]] (an integral Number) and [[Bytes]] (a List of byte values), or a throw completion
+    </h1>
+    <dl class="header">
+    </dl>
+    <emu-alg>
+      1. If _maxLength_ is not present, then
+        1. Let _maxLength_ be 2<sup>53</sup> - 1.
+        1. NOTE: Because the input is a string, the length of strings is limited to 2<sup>53</sup> - 1 characters, and the output requires no more bytes than the input has characters, this limit can never be reached. However, it is editorially convenient to use a finite value here.
+      1. NOTE: The order of validation and decoding in the algorithm below is not observable. Implementations are encouraged to perform them in whatever order is most efficient, possibly interleaving validation with decoding, as long as the behaviour is observably equivalent.
+      1. If _maxLength_ is 0, then
+        1. Return the Record { [[Read]]: 0, [[Bytes]]: « » }.
+      1. Let _read_ be 0.
+      1. Let _bytes_ be « ».
+      1. Let _chunk_ be the empty String.
+      1. Let _chunkLength_ be 0.
+      1. Let _index_ be 0.
+      1. Let _length_ be the length of _string_.
+      1. Repeat,
+        1. Set _index_ to SkipAsciiWhitespace(_string_, _index_).
+        1. If _index_ = _length_, then
+          1. If _chunkLength_ > 0, then
+            1. If _lastChunkHandling_ is *"stop-before-partial"*, then
+              1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
+            1. Else if _lastChunkHandling_ is *"loose"*, then
+              1. If _chunkLength_ is 1, then
+                1. Throw a *SyntaxError* exception.
+              1. Set _bytes_ to the list-concatenation of _bytes_ and ? DecodeBase64Chunk(_chunk_, _alphabet_, *false*).
+            1. Else,
+              1. Assert: _lastChunkHandling_ is *"strict"*.
+              1. Throw a *SyntaxError* exception.
+          1. Return the Record { [[Read]]: _length_, [[Bytes]]: _bytes_ }.
+        1. Let _char_ be the substring of _string_ from _index_ to _index_ + 1.
+        1. Set _index_ to _index_ + 1.
+        1. If _char_ is *"="*, then
+          1. If _chunkLength_ < 2, then
+            1. Throw a *SyntaxError* exception.
+          1. Set _index_ to SkipAsciiWhitespace(_string_, _index_).
+          1. If _chunkLength_ = 2, then
+            1. If _index_ = _length_, then
+              1. If _lastChunkHandling_ is *"stop-before-partial"*, then
+                1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
+              1. Throw a *SyntaxError* exception.
+            1. Set _char_ to the substring of _string_ from _index_ to _index_ + 1.
+            1. If _char_ is *"="*, then
+              1. Set _index_ to SkipAsciiWhitespace(_string_, _index_ + 1).
+          1. If _index_ < _length_, then
+            1. Throw a *SyntaxError* exception.
+          1. If _lastChunkHandling_ is *"strict"*, let _throwOnExtraBits_ be *true*.
+          1. Else, let _throwOnExtraBits_ be *false*.
+          1. Set _bytes_ to the list-concatenation of _bytes_ and ? DecodeBase64Chunk(_chunk_, _alphabet_, _throwOnExtraBits_).
+          1. Return the Record { [[Read]]: _length_, [[Bytes]]: _bytes_ }.
+        1. Let _remaining_ be _maxLength_ - the length of _bytes_.
+        1. If _remaining_ = 1 and _chunkLength_ = 2, or if _remaining_ = 2 and _chunkLength_ = 3, then
+          1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
+        1. Set _chunk_ to the string-concatenation of _chunk_ and _char_.
+        1. Set _chunkLength_ to the length of _chunk_.
+        1. If _chunkLength_ = 4, then
+          1. Set _bytes_ to the list-concatenation of _bytes_ and ? DecodeBase64Chunk(_chunk_, _alphabet_).
+          1. Set _chunk_ to the empty String.
+          1. Set _chunkLength_ to 0.
+          1. Set _read_ to _index_.
+          1. If the length of _bytes_ = _maxLength_, then
+            1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-fromhex" type="abstract operation">
+    <h1>
+      FromHex (
+        _string_: a string,
+        optional _maxLength_: a non-negative integer,
+      ): either a normal completion containing a Record with fields [[Read]] (an integral Number) and [[Bytes]] (a List of byte values), or a throw completion
+    </h1>
+    <dl class="header">
+    </dl>
+    <emu-alg>
+      1. If _maxLength_ is not present, let _maxLength_ be 2<sup>53</sup> - 1.
+      1. Let _length_ be the length of _string_.
+      1. If _length_ modulo 2 is not 0, throw a *SyntaxError* exception.
+      1. If _string_ contains any code units which are not in *"0123456789abcdefABCDEF"*, throw a *SyntaxError* exception.
+      1. Let _bytes_ be « ».
+      1. Let _index_ be 0.
+      1. Repeat, while _index_ &lt; _length_,
+        1. Let _hexits_ be the substring of _string_ from _index_ to _index_ + 2.
+        1. Set _index_ to _index_ + 2.
+        1. Let _byte_ be the integer value represented by _hexits_ in base-16 notation, using the letters A-F and a-f for digits with values 10 through 15.
+        1. Append _byte_ to _bytes_.
+        1. If the length of _bytes_ is _maxLength_, then
+          1. Return the Record { [[Read]]: _index_, [[Bytes]]: _bytes_ }.
+      1. Return the Record { [[Read]]: _index_, [[Bytes]]: _bytes_ }.
+    </emu-alg>
+  </emu-clause>
+
+  <!-- Copied from ECMA-402/Temporal -->
+
+  <emu-clause id="sec-getoptionsobject" aoid="GetOptionsObject">
+    <h1>GetOptionsObject ( _options_ )</h1>
+    <emu-alg>
+      1. If _options_ is *undefined*, then
+        1. Return OrdinaryObjectCreate(*null*).
+      1. If Type(_options_) is Object, then
+        1. Return _options_.
+      1. Throw a *TypeError* exception.
+    </emu-alg>
+  </emu-clause>
 </emu-clause>
 
 <emu-annex id="sec-modified-bibliography">

--- a/test-polyfill.mjs
+++ b/test-polyfill.mjs
@@ -163,13 +163,6 @@ test('writing to an existing buffer', async t => {
     assert.deepStrictEqual([...output], [...foobarOutput.slice(0, 5), 0, 0, 0]);
     assert.deepStrictEqual({ read, written }, { read: 17, written: 5 });
   });
-
-  await t.test('buffer exact, padded, outputOffset', () => {
-    let output = new Uint8Array(6);
-    let { read, written } = Uint8Array.fromBase64Into(foobaInput + '=', output, { outputOffset: 1 });
-    assert.deepStrictEqual([...output], [0, ...foobarOutput.slice(0, 5)]);
-    assert.deepStrictEqual({ read, written }, { read: 8, written: 5 });
-  });
 });
 
 test('stop-before-partial', async t => {

--- a/test-polyfill.mjs
+++ b/test-polyfill.mjs
@@ -1,12 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 
-import {
-  uint8ArrayToBase64,
-  base64ToUint8Array,
-  uint8ArrayToHex,
-  hexToUint8Array,
-} from './playground/polyfill-core.mjs';
+import './playground/polyfill-install.mjs';
 
 let stringToBytes = str => new TextEncoder().encode(str);
 
@@ -23,10 +18,10 @@ let standardBase64Vectors = [
 test('standard vectors', async t => {
   for (let [string, result] of standardBase64Vectors) {
     await t.test(JSON.stringify(string), () => {
-      assert.strictEqual(uint8ArrayToBase64(stringToBytes(string)), result);
+      assert.strictEqual(stringToBytes(string).toBase64(), result);
 
-      assert.deepStrictEqual(base64ToUint8Array(result), stringToBytes(string));
-      assert.deepStrictEqual(base64ToUint8Array(result, { strict: true }), stringToBytes(string));
+      assert.deepStrictEqual(Uint8Array.fromBase64(result), stringToBytes(string));
+      assert.deepStrictEqual(Uint8Array.fromBase64(result, { lastChunkHandling: 'strict' }), stringToBytes(string));
     });
   }
 });
@@ -35,8 +30,8 @@ let malformedPadding = ['=', 'Zg=', 'Z===', 'Zm8==', 'Zm9v='];
 test('malformed padding', async t => {
   for (let string of malformedPadding) {
     await t.test(JSON.stringify(string), () => {
-      assert.throws(() => base64ToUint8Array(string), SyntaxError);
-      assert.throws(() => base64ToUint8Array(string, { strict: true }), SyntaxError);
+      assert.throws(() => Uint8Array.fromBase64(string), SyntaxError);
+      assert.throws(() => Uint8Array.fromBase64(string, { lastChunkHandling: 'strict' }), SyntaxError);
     });
   }
 });
@@ -54,8 +49,8 @@ let illegal = [
 test('illegal characters', async t => {
   for (let string of malformedPadding) {
     await t.test(JSON.stringify(string), () => {
-      assert.throws(() => base64ToUint8Array(string), SyntaxError);
-      assert.throws(() => base64ToUint8Array(string, { strict: true }), SyntaxError);
+      assert.throws(() => Uint8Array.fromBase64(string), SyntaxError);
+      assert.throws(() => Uint8Array.fromBase64(string, { lastChunkHandling: 'strict' }), SyntaxError);
     });
   }
 });
@@ -71,24 +66,160 @@ let onlyNonStrict = [
 test('only valid in non-strict', async t => {
   for (let [encoded, decoded] of onlyNonStrict) {
     await t.test(JSON.stringify(encoded), () => {
-      assert.deepStrictEqual(base64ToUint8Array(encoded), decoded);
-      assert.throws(() => base64ToUint8Array(encoded, { strict: true }), SyntaxError);
+      assert.deepStrictEqual(Uint8Array.fromBase64(encoded), decoded);
+      assert.throws(() => Uint8Array.fromBase64(encoded, { lastChunkHandling: 'strict' }), SyntaxError);
     });
   }
 });
 
 test('alphabet-specific strings', async t => {
   let standardOnly = 'x+/y';
+
   await t.test(JSON.stringify(standardOnly), () => {
-    assert.deepStrictEqual(base64ToUint8Array(standardOnly), Uint8Array.of(0xc7, 0xef, 0xf2));
-    assert.deepStrictEqual(base64ToUint8Array(standardOnly, { alphabet: 'base64' }), Uint8Array.of(0xc7, 0xef, 0xf2));
-    assert.throws(() => base64ToUint8Array(standardOnly, { alphabet: 'base64url' }), SyntaxError);
+    assert.deepStrictEqual(Uint8Array.fromBase64(standardOnly), Uint8Array.of(0xc7, 0xef, 0xf2));
+    assert.deepStrictEqual(Uint8Array.fromBase64(standardOnly, { alphabet: 'base64' }), Uint8Array.of(0xc7, 0xef, 0xf2));
+    assert.throws(() => Uint8Array.fromBase64(standardOnly, { alphabet: 'base64url' }), SyntaxError);
   });
 
   let urlOnly = 'x-_y';
   await t.test(JSON.stringify(urlOnly), () => {
-    assert.deepStrictEqual(base64ToUint8Array(urlOnly, { alphabet: 'base64url' }), Uint8Array.of(0xc7, 0xef, 0xf2));
-    assert.throws(() => base64ToUint8Array(urlOnly), SyntaxError);
-    assert.throws(() => base64ToUint8Array(urlOnly, { alphabet: 'base64' }), SyntaxError);
+    assert.deepStrictEqual(Uint8Array.fromBase64(urlOnly, { alphabet: 'base64url' }), Uint8Array.of(0xc7, 0xef, 0xf2));
+    assert.throws(() => Uint8Array.fromBase64(urlOnly), SyntaxError);
+    assert.throws(() => Uint8Array.fromBase64(urlOnly, { alphabet: 'base64' }), SyntaxError);
+  });
+});
+
+test('writing to an existing buffer', async t => {
+  let foobarInput = 'Zm9vYmFy';
+  let foobaInput = 'Zm9vYmE';
+  let foobarOutput = [102, 111, 111, 98, 97, 114];
+
+  await t.test('buffer exact', () => {
+    let output = new Uint8Array(6);
+    let { read, written } = Uint8Array.fromBase64Into(foobarInput, output);
+    assert.deepStrictEqual([...output], foobarOutput);
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 6 });
+  });
+
+  await t.test('buffer too large', () => {
+    let output = new Uint8Array(8);
+    let { read, written } = Uint8Array.fromBase64Into(foobarInput, output);
+    assert.deepStrictEqual([...output], [...foobarOutput, 0, 0]);
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 6 });
+  });
+
+  await t.test('buffer too small', () => {
+    let output = new Uint8Array(5);
+    let { read, written } = Uint8Array.fromBase64Into(foobarInput, output);
+    assert.deepStrictEqual([...output], [...foobarOutput.slice(0, 3), 0, 0]);
+    assert.deepStrictEqual({ read, written }, { read: 4, written: 3 });
+  });
+
+  await t.test('buffer exact, padded', () => {
+    let output = new Uint8Array(5);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput + '=', output);
+    assert.deepStrictEqual([...output], foobarOutput.slice(0, 5));
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 5 });
+  });
+
+  await t.test('buffer exact, not padded', () => {
+    let output = new Uint8Array(5);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput, output);
+    assert.deepStrictEqual([...output], foobarOutput.slice(0, 5));
+    assert.deepStrictEqual({ read, written }, { read: 7, written: 5 });
+  });
+
+  await t.test('buffer exact, padded, stop-before-partial', () => {
+    let output = new Uint8Array(5);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput + '=', output , { lastChunkHandling: 'stop-before-partial' });
+    assert.deepStrictEqual([...output], foobarOutput.slice(0, 5));
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 5 });
+  });
+
+  await t.test('buffer exact, not padded, stop-before-partial', () => {
+    let output = new Uint8Array(5);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput, output , { lastChunkHandling: 'stop-before-partial' });
+    assert.deepStrictEqual([...output], [...foobarOutput.slice(0, 3), 0, 0]);
+    assert.deepStrictEqual({ read, written }, { read: 4, written: 3 });
+  });
+
+  await t.test('buffer too small, padded', () => {
+    let output = new Uint8Array(4);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput + '=', output);
+    assert.deepStrictEqual([...output], [...foobarOutput.slice(0, 3), 0]);
+    assert.deepStrictEqual({ read, written }, { read: 4, written: 3 });
+  });
+
+  await t.test('buffer too large, trailing whitespace', () => {
+    let output = new Uint8Array(8);
+    let { read, written } = Uint8Array.fromBase64Into(foobarInput + ' '.repeat(10), output);
+    assert.deepStrictEqual([...output], [...foobarOutput, 0, 0]);
+    assert.deepStrictEqual({ read, written }, { read: 18, written: 6 });
+  });
+
+  await t.test('buffer too large, not padded, trailing whitespace', () => {
+    let output = new Uint8Array(8);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput + ' '.repeat(10), output);
+    assert.deepStrictEqual([...output], [...foobarOutput.slice(0, 5), 0, 0, 0]);
+    assert.deepStrictEqual({ read, written }, { read: 17, written: 5 });
+  });
+
+  await t.test('buffer exact, padded, outputOffset', () => {
+    let output = new Uint8Array(6);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput + '=', output, { outputOffset: 1 });
+    assert.deepStrictEqual([...output], [0, ...foobarOutput.slice(0, 5)]);
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 5 });
+  });
+});
+
+test('stop-before-partial', async t => {
+  let foobaInput = 'Zm9vYmE';
+  let foobarOutput = [102, 111, 111, 98, 97, 114];
+
+  await t.test('no padding', () => {
+    let output = Uint8Array.fromBase64(foobaInput, { lastChunkHandling: 'stop-before-partial' });
+    assert.deepStrictEqual([...output], foobarOutput.slice(0, 3));
+  });
+
+  await t.test('padding', () => {
+    let output = Uint8Array.fromBase64(foobaInput + '=', { lastChunkHandling: 'stop-before-partial' });
+    assert.deepStrictEqual([...output], foobarOutput.slice(0, 5));
+  });
+
+  await t.test('no padding, trailing whitespace', () => {
+    let output = new Uint8Array(8);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput + ' '.repeat(10), output, { lastChunkHandling: 'stop-before-partial' });
+    assert.deepStrictEqual([...output], [...foobarOutput.slice(0, 3), 0, 0, 0, 0, 0]);
+    assert.deepStrictEqual({ read, written }, { read: 4, written: 3 });
+  });
+});
+
+test('hex', async t => {
+  let encoded = 'deadBEEF';
+  let decoded = [222, 173, 190, 239];
+
+  await t.test('basic decode', () => {
+    assert.deepStrictEqual([...Uint8Array.fromHex(encoded)], decoded);
+  });
+
+  await t.test('decode into, exact', () => {
+    let output = new Uint8Array(4);
+    let { read, written } = Uint8Array.fromHexInto(encoded, output);
+    assert.deepStrictEqual([...output], decoded);
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 4 });
+  });
+
+  await t.test('decode into, buffer too large', () => {
+    let output = new Uint8Array(6);
+    let { read, written } = Uint8Array.fromHexInto(encoded, output);
+    assert.deepStrictEqual([...output], [...decoded, 0, 0]);
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 4 });
+  });
+
+  await t.test('decode into, buffer too small', () => {
+    let output = new Uint8Array(3);
+    let { read, written } = Uint8Array.fromHexInto(encoded, output);
+    assert.deepStrictEqual([...output], decoded.slice(0, 3));
+    assert.deepStrictEqual({ read, written }, { read: 6, written: 3 });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/tc39/proposal-arraybuffer-base64/issues/21: this adds `let {read, written } = Uint8Array.fromBase64Into(string, target, options)` and `let { read, written } = Uint8Array.fromHexInto(string, target, options)` methods which allow writing to an existing Uint8Array, matching `TextEncoder`'s `encodeInto()`.

~~These methods also add an `outputOffset` option in the options bag which lets you specify an offset to start writing at, letting you skip the `subarray` call. `TextEncoder` doesn't have this but apparently it's important for V8.~~ Moved this part into https://github.com/tc39/proposal-arraybuffer-base64/pull/34.

Also fixes https://github.com/tc39/proposal-arraybuffer-base64/issues/13: this adds a `lastChunkHandling: 'stop-before-partial'` option to the base64 decoders, which allows an efficient streaming decoder to be implemented in userland (efficient meaning, no passes over the input string in userland). See the updated `stream.mjs`. The other values for `lastChunkHandling` are "loose" and "strict"; "strict" enforces padding and zero-ness of overflow bits. "loose" is the default and matches the behavior of `atob`.

As a consequence of the refactor to use `lastChunkHandling`, there's no longer an option to forbid whitespace in the base64 decoders. This is easy to do in userland if you really want to, though there is rarely occasion for it. Whitespace is always permitted in the base64 decoder, and never in the hex decoder.

When this lands the proposal should be ready for stage 3 (or rather 2.7).

cc @phoddie @syg