### PR TITLE
add outputOffset to the `into` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ assert.deepStrictEqual([...target], [102, 111, 111, 98, 97, 114, 0, 0]);
 assert.deepStrictEqual({ read, written }, { read: 8, written: 6 });
 ```
 
-This method takes an optional final options bag with the same options as above.
-
-As with `encodeInto`, there is not explicit support for writing to specified offset of the target, but you can accomplish that by creating a subarray.
+This method takes an optional final options bag with the same options as above, plus an `outputOffset` option which allows specifying a position in the target array to write to without needing to create a subarray.
 
 `Uint8Array.fromHexInto` is the same except for hex.
 

--- a/playground/index-raw.html
+++ b/playground/index-raw.html
@@ -114,7 +114,7 @@ try {
 <h3>Writing to an existing Uint8Array</h3>
 <p>The <code>Uint8Array.fromBase64Into</code> method allows writing to an existing Uint8Array. Like the <a href="https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encodeInto">TextEncoder <code>encodeInto</code> method</a>, it returns a <code>{ read, written }</code> pair.</p>
 
-<p>This method takes an optional final options bag with the same options as above.</p>
+<p>This method takes an optional final options bag with the same options as above, plus an <code>outputOffset</code> option which allows specifying a position in the target array to write to without needing to create a subarray.</p>
 
 <pre class="language-js"><code class="language-js">
 let target = new Uint8Array(7);

--- a/playground/polyfill-install.mjs
+++ b/playground/polyfill-install.mjs
@@ -31,11 +31,11 @@ Uint8Array.fromHex = function (string) {
   return hexToUint8Array(string).bytes;
 };
 
-Uint8Array.fromHexInto = function (string, into) {
+Uint8Array.fromHexInto = function (string, into, options) {
   if (typeof string !== 'string') {
     throw new TypeError('expected input to be a string');
   }
   checkUint8Array(into);
-  let { read, bytes } = hexToUint8Array(string, into);
+  let { read, bytes } = hexToUint8Array(string, options, into);
   return { read, written: bytes.length };
 };

--- a/spec.html
+++ b/spec.html
@@ -81,15 +81,21 @@ contributors: Kevin Gibbons
     1. Let _lastChunkHandling_ be ? Get(_opts_, *"lastChunkHandling"*).
     1. If _lastChunkHandling_ is *undefined*, set _lastChunkHandling_ to *"loose"*.
     1. If _lastChunkHandling_ is not one of *"loose"*, *"strict"*, or *"stop-before-partial"*, throw a *TypeError* exception.
+    1. Let _outputOffset_ be ? Get(_opts_, *"outputOffset"*).
+    1. If _outputOffset_ is *undefined*, set _outputOffset_ to *+0*<sub>𝔽</sub>.
+    1. If _outputOffset_ is not an integral Number, throw a *RangeError* exception.
+    1. Set _outputOffset_ to ℝ(_outputOffset_).
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
     1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
-    1. Let _maxLength_ be _byteLength_.
+    1. If _outputOffset_ < 0 or _outputOffset_ ≥ _byteLength_, then
+      1. Throw a *RangeError* exception.
+    1. Let _maxLength_ be _byteLength_ - _outputOffset_.
     1. Let _result_ be ? FromBase64(_string_, _alphabet_, _lastChunkHandling_, _maxLength_).
     1. Let _bytes_ be _result_.[[Bytes]].
     1. Let _written_ be the length of _bytes_.
     1. NOTE: FromBase64 does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
     1. Assert: _written_ ≤ _byteLength_.
-    1. Let _offset_ be _into_.[[ByteOffset]].
+    1. Let _offset_ be _into_.[[ByteOffset]] + _outputOffset_.
     1. Let _index_ be 0.
     1. Repeat, while _index_ < _written_,
       1. Let _byte_ be _bytes_[i].
@@ -115,20 +121,27 @@ contributors: Kevin Gibbons
 </emu-clause>
 
 <emu-clause id="sec-uint8array.fromhexinto">
-  <h1>Uint8Array.fromHexInto ( _string_, _into_ )</h1>
+  <h1>Uint8Array.fromHexInto ( _string_, _into_ [ , _options_ ] )</h1>
   <emu-alg>
     1. If _string_ is not a String, throw a *TypeError* exception.
     1. Perform ? RequireInternalSlot(_into_, [[TypedArrayName]]).
     1. If _into_.[[TypedArrayName]] is not *"Uint8Array"*, throw a *TypeError* exception.
+    1. Let _opts_ be ? GetOptionsObject(_options_).
+    1. Let _outputOffset_ be ? Get(_opts_, *"outputOffset"*).
+    1. If _outputOffset_ is *undefined*, set _outputOffset_ to *+0*<sub>𝔽</sub>.
+    1. If _outputOffset_ is not an integral Number, throw a *RangeError* exception.
+    1. Set _outputOffset_ to ℝ(_outputOffset_).
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
     1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
-    1. Let _maxLength_ be _byteLength_.
+    1. If _outputOffset_ < 0 or _outputOffset_ ≥ _byteLength_, then
+      1. Throw a *RangeError* exception.
+    1. Let _maxLength_ be _byteLength_ - _outputOffset_.
     1. Let _result_ be ? FromHex(_string_, _maxLength_).
     1. Let _bytes_ be _result_.[[Bytes]].
     1. Let _written_ be the length of _bytes_.
     1. NOTE: FromHex does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
     1. Assert: _written_ ≤ _byteLength_.
-    1. Let _offset_ be _into_.[[ByteOffset]].
+    1. Let _offset_ be _into_.[[ByteOffset]] + _outputOffset_.
     1. Let _index_ be 0.
     1. Repeat, while _index_ < _written_,
       1. Let _byte_ be _bytes_[i].

--- a/test-polyfill.mjs
+++ b/test-polyfill.mjs
@@ -163,6 +163,13 @@ test('writing to an existing buffer', async t => {
     assert.deepStrictEqual([...output], [...foobarOutput.slice(0, 5), 0, 0, 0]);
     assert.deepStrictEqual({ read, written }, { read: 17, written: 5 });
   });
+
+  await t.test('buffer exact, padded, outputOffset', () => {
+    let output = new Uint8Array(6);
+    let { read, written } = Uint8Array.fromBase64Into(foobaInput + '=', output, { outputOffset: 1 });
+    assert.deepStrictEqual([...output], [0, ...foobarOutput.slice(0, 5)]);
+    assert.deepStrictEqual({ read, written }, { read: 8, written: 5 });
+  });
 });
 
 test('stop-before-partial', async t => {


### PR DESCRIPTION
Split out out from https://github.com/tc39/proposal-arraybuffer-base64/pull/33.

Won't be in this proposal unless implementation or user feedback demonstrates need during stage 3.