### PR TITLE
Normative: throw when trying to write to a detached buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "proposal-arraybuffer-base64",
       "dependencies": {
-        "@tc39/ecma262-biblio": "^2.1.2663",
+        "@tc39/ecma262-biblio": "2.1.2672",
         "ecmarkup": "^18.0.0",
         "jsdom": "^21.1.1",
         "prismjs": "^1.29.0"
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "2.1.2663",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2663.tgz",
-      "integrity": "sha512-CZgOFz73hKQVXFLPpaFfMNRVx+xQxXnUlQEC8Nde/r4W2g9e1c0C8gzxAZOP+v8IQLFn09xXnVz/GN9Ry3YN1w=="
+      "version": "2.1.2672",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2672.tgz",
+      "integrity": "sha512-S4AVovjzgm9cq1O2Odn7y+OqZ3LNKVGzhd5zVggueFogQyQPw8mpaIzdGxqrm7jmkRtnggO9i+NY5g23GCBXNg=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@tc39/ecma262-biblio": "^2.1.2663",
+    "@tc39/ecma262-biblio": "2.1.2672",
     "ecmarkup": "^18.0.0",
     "jsdom": "^21.1.1",
     "prismjs": "^1.29.0"

--- a/playground/polyfill-core.mjs
+++ b/playground/polyfill-core.mjs
@@ -224,6 +224,9 @@ export function base64ToUint8Array(string, options, into) {
   if (!['loose', 'strict', 'stop-before-partial'].includes(lastChunkHandling)) {
     throw new TypeError('expected lastChunkHandling to be either "loose", "strict", or "stop-before-partial"');
   }
+  if (into && 'detached' in into.buffer && into.buffer.detached) {
+    throw new TypeError('toBase64Into called on array backed by detached buffer');
+  }
 
   let maxLength = into ? into.length : 2 ** 53 - 1;
 
@@ -259,6 +262,9 @@ export function hexToUint8Array(string, into) {
   }
   if (/[^0-9a-fA-F]/.test(string)) {
     throw new SyntaxError('string should only contain hex characters');
+  }
+  if (into && 'detached' in into.buffer && into.buffer.detached) {
+    throw new TypeError('fromHexInto called on array backed by detached buffer');
   }
 
   let maxLength = into ? into.length : 2 ** 53 - 1;

--- a/spec.html
+++ b/spec.html
@@ -83,6 +83,7 @@ contributors: Kevin Gibbons
     1. If _lastChunkHandling_ is *undefined*, set _lastChunkHandling_ to *"loose"*.
     1. If _lastChunkHandling_ is not one of *"loose"*, *"strict"*, or *"stop-before-partial"*, throw a *TypeError* exception.
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
+    1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
     1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
     1. Let _maxLength_ be _byteLength_.
     1. Let _result_ be ? FromBase64(_string_, _alphabet_, _lastChunkHandling_, _maxLength_).
@@ -121,6 +122,7 @@ contributors: Kevin Gibbons
     1. If _string_ is not a String, throw a *TypeError* exception.
     1. Perform ? ValidateUint8Array(_into_).
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
+    1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
     1. Let _byteLength_ be TypedArrayByteLength(_taRecord_).
     1. Let _maxLength_ be _byteLength_.
     1. Let _result_ be ? FromHex(_string_, _maxLength_).


### PR DESCRIPTION
Fixes #40, cc @anba.

I originally treated detached/OOB buffers as zero-length to match TextEncoder's `encodeInto`, but [that was probably an oversight](https://github.com/whatwg/webidl/issues/1385#issuecomment-1907555893) and [might be fixable](https://github.com/whatwg/encoding/issues/324).

So we throw instead.