### PR TITLE
[spec] `FromHex`: refactor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -332,14 +332,12 @@ contributors: Kevin Gibbons
       1. If _length_ modulo 2 is not 0, throw a *SyntaxError* exception.
       1. Let _bytes_ be « ».
       1. Let _index_ be 0.
-      1. Repeat, while _index_ &lt; _length_,
+      1. Repeat, while _index_ &lt; _length_ and the length of _bytes_ &lt; _maxLength_,
         1. Let _hexits_ be the substring of _string_ from _index_ to _index_ + 2.
         1. If _hexits_ contains any code units which are not in *"0123456789abcdefABCDEF"*, throw a *SyntaxError* exception.
         1. Set _index_ to _index_ + 2.
         1. Let _byte_ be the integer value represented by _hexits_ in base-16 notation, using the letters A-F and a-f for digits with values 10 through 15.
         1. Append _byte_ to _bytes_.
-        1. If the length of _bytes_ is _maxLength_, then
-          1. Return the Record { [[Read]]: _index_, [[Bytes]]: _bytes_ }.
       1. Return the Record { [[Read]]: _index_, [[Bytes]]: _bytes_ }.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
this matches what you did in your polyfill anyways, and makes the algorithm cleaner imo.

If having "the length of bytes" in there is weird, then my fallback would be, changing the return in step 6.f.i to `set index = length` so the return point isn't repeated, but that's a lot more subjective of an improvement to be fair.