### PR TITLE
write data up until error in setFromX methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -59,7 +59,9 @@ contributors: Kevin Gibbons
     1. Let _lastChunkHandling_ be ? Get(_opts_, *"lastChunkHandling"*).
     1. If _lastChunkHandling_ is *undefined*, set _lastChunkHandling_ to *"loose"*.
     1. If _lastChunkHandling_ is not one of *"loose"*, *"strict"*, or *"stop-before-partial"*, throw a *TypeError* exception.
-    1. Let _result_ be ? FromBase64(_string_, _alphabet_, _lastChunkHandling_).
+    1. Let _result_ be FromBase64(_string_, _alphabet_, _lastChunkHandling_).
+    1. If _result_.[[Error]] is not ~none~, then
+      1. Throw _result_.[[Error]].
     1. Let _resultLength_ be the length of _result_.[[Bytes]].
     1. Let _ta_ be ? <emu-meta suppress-effects="user-code">AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, *"%Uint8Array.prototype%"*, _resultLength_)</emu-meta>.
     1. Set the value at each index of _ta_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _result_.[[Bytes]].
@@ -83,12 +85,14 @@ contributors: Kevin Gibbons
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
     1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
     1. Let _byteLength_ be TypedArrayLength(_taRecord_).
-    1. Let _result_ be ? FromBase64(_string_, _alphabet_, _lastChunkHandling_, _byteLength_).
+    1. Let _result_ be FromBase64(_string_, _alphabet_, _lastChunkHandling_, _byteLength_).
     1. Let _bytes_ be _result_.[[Bytes]].
     1. Let _written_ be the length of _bytes_.
     1. NOTE: FromBase64 does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
     1. Assert: _written_ ≤ _byteLength_.
     1. Perform SetUint8ArrayBytes(_into_, _bytes_).
+    1. If _result_.[[Error]] is not ~none~, then
+      1. Throw _result_.[[Error]].
     1. Let _resultObject_ be OrdinaryObjectCreate(%Object.prototype%).
     1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"read"*, 𝔽(_result_.[[Read]])).
     1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"written"*, 𝔽(_written_)).
@@ -100,7 +104,9 @@ contributors: Kevin Gibbons
   <h1>Uint8Array.fromHex ( _string_ )</h1>
   <emu-alg>
     1. If _string_ is not a String, throw a *TypeError* exception.
-    1. Let _result_ be ? FromHex(_string_).
+    1. Let _result_ be FromHex(_string_).
+    1. If _result_.[[Error]] is not ~none~, then
+      1. Throw _result_.[[Error]].
     1. Let _resultLength_ be the length of _result_.[[Bytes]].
     1. Let _ta_ be ? <emu-meta suppress-effects="user-code">AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, *"%Uint8Array.prototype%"*, _resultLength_)</emu-meta>.
     1. Set the value at each index of _ta_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _result_.[[Bytes]].
@@ -117,12 +123,14 @@ contributors: Kevin Gibbons
     1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_into_, ~seq-cst~).
     1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
     1. Let _byteLength_ be TypedArrayLength(_taRecord_).
-    1. Let _result_ be ? FromHex(_string_, _byteLength_).
+    1. Let _result_ be FromHex(_string_, _byteLength_).
     1. Let _bytes_ be _result_.[[Bytes]].
     1. Let _written_ be the length of _bytes_.
     1. NOTE: FromHex does not invoke any user code, so the ArrayBuffer backing _into_ cannot have been detached or shrunk.
     1. Assert: _written_ ≤ _byteLength_.
     1. Perform SetUint8ArrayBytes(_into_, _bytes_).
+    1. If _result_.[[Error]] is not ~none~, then
+      1. Throw _result_.[[Error]].
     1. Let _resultObject_ be OrdinaryObjectCreate(%Object.prototype%).
     1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"read"*, 𝔽(_result_.[[Read]])).
     1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"written"*, 𝔽(_written_)).
@@ -253,7 +261,7 @@ contributors: Kevin Gibbons
         _alphabet_: *"base64"* or *"base64url"*,
         _lastChunkHandling_: *"loose"*, *"strict"*, or *"stop-before-partial"*,
         optional _maxLength_: a non-negative integer,
-      ): either a normal completion containing a Record with fields [[Read]] (an integral Number) and [[Bytes]] (a List of byte values), or a throw completion
+      ): a Record with fields [[Read]] (an integral Number), [[Bytes]] (a List of byte values), and [[Error]] (either ~none~ or a throw completion)
     </h1>
     <dl class="header">
     </dl>
@@ -263,7 +271,7 @@ contributors: Kevin Gibbons
         1. NOTE: Because the input is a string, the length of strings is limited to 2<sup>53</sup> - 1 characters, and the output requires no more bytes than the input has characters, this limit can never be reached. However, it is editorially convenient to use a finite value here.
       1. NOTE: The order of validation and decoding in the algorithm below is not observable. Implementations are encouraged to perform them in whatever order is most efficient, possibly interleaving validation with decoding, as long as the behaviour is observably equivalent.
       1. If _maxLength_ is 0, then
-        1. Return the Record { [[Read]]: 0, [[Bytes]]: « » }.
+        1. Return the Record { [[Read]]: 0, [[Bytes]]: « », [[Error]]: ~none~ }.
       1. Let _read_ be 0.
       1. Let _bytes_ be « ».
       1. Let _chunk_ be the empty String.
@@ -275,43 +283,58 @@ contributors: Kevin Gibbons
         1. If _index_ = _length_, then
           1. If _chunkLength_ > 0, then
             1. If _lastChunkHandling_ is *"stop-before-partial"*, then
-              1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
+              1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
             1. Else if _lastChunkHandling_ is *"loose"*, then
               1. If _chunkLength_ is 1, then
-                1. Throw a *SyntaxError* exception.
+                1. Let _error_ be a new *SyntaxError* exception.
+                1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
               1. Set _bytes_ to the list-concatenation of _bytes_ and ! DecodeBase64Chunk(_chunk_, *false*).
             1. Else,
               1. Assert: _lastChunkHandling_ is *"strict"*.
-              1. Throw a *SyntaxError* exception.
-          1. Return the Record { [[Read]]: _length_, [[Bytes]]: _bytes_ }.
+              1. Let _error_ be a new *SyntaxError* exception.
+              1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
+          1. Return the Record { [[Read]]: _length_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
         1. Let _char_ be the substring of _string_ from _index_ to _index_ + 1.
         1. Set _index_ to _index_ + 1.
         1. If _char_ is *"="*, then
           1. If _chunkLength_ < 2, then
-            1. Throw a *SyntaxError* exception.
+            1. Let _error_ be a new *SyntaxError* exception.
+            1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
           1. Set _index_ to SkipAsciiWhitespace(_string_, _index_).
           1. If _chunkLength_ = 2, then
             1. If _index_ = _length_, then
               1. If _lastChunkHandling_ is *"stop-before-partial"*, then
-                1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
-              1. Throw a *SyntaxError* exception.
+                1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
+              1. Let _error_ be a new *SyntaxError* exception.
+              1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
             1. Set _char_ to the substring of _string_ from _index_ to _index_ + 1.
             1. If _char_ is *"="*, then
               1. Set _index_ to SkipAsciiWhitespace(_string_, _index_ + 1).
           1. If _index_ < _length_, then
-            1. Throw a *SyntaxError* exception.
+            1. Let _error_ be a new *SyntaxError* exception.
+            1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
           1. If _lastChunkHandling_ is *"strict"*, let _throwOnExtraBits_ be *true*.
           1. Else, let _throwOnExtraBits_ be *false*.
-          1. Set _bytes_ to the list-concatenation of _bytes_ and ? DecodeBase64Chunk(_chunk_, _throwOnExtraBits_).
-          1. Return the Record { [[Read]]: _length_, [[Bytes]]: _bytes_ }.
+          1. Let _decodeResult_ be Completion(DecodeBase64Chunk(_chunk_, _throwOnExtraBits_)).
+          1. If _decodeResult_ is an abrupt completion, then
+            1. Let _error_ be _decodeResult_.[[Value]].
+            1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
+          1. Set _bytes_ to the list-concatenation of _bytes_ and ! _decodeResult_.
+          1. Return the Record { [[Read]]: _length_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
         1. If _alphabet_ is *"base64url"*, then
-          1. If _char_ is either *"+"* or *"/"*, throw a *SyntaxError* exception.
-          1. Else if _char_ is *"-"*, set _char_ to *"+"*.
-          1. Else if _char_ is *"_"*, set _char_ to *"/"*.
-        1. If the sole code unit of _char_ is not an element of the standard base64 alphabet, throw a *SyntaxError* exception.
+          1. If _char_ is either *"+"* or *"/"*, then
+            1. Let _error_ be a new *SyntaxError* exception.
+            1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
+          1. Else if _char_ is *"-"*, then
+            1. Set _char_ to *"+"*.
+          1. Else if _char_ is *"_"*, then
+            1. Set _char_ to *"/"*.
+        1. If the sole code unit of _char_ is not an element of the standard base64 alphabet, then
+          1. Let _error_ be a new *SyntaxError* exception.
+          1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
         1. Let _remaining_ be _maxLength_ - the length of _bytes_.
         1. If _remaining_ = 1 and _chunkLength_ = 2, or if _remaining_ = 2 and _chunkLength_ = 3, then
-          1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
+          1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
         1. Set _chunk_ to the string-concatenation of _chunk_ and _char_.
         1. Set _chunkLength_ to the length of _chunk_.
         1. If _chunkLength_ = 4, then
@@ -320,7 +343,7 @@ contributors: Kevin Gibbons
           1. Set _chunkLength_ to 0.
           1. Set _read_ to _index_.
           1. If the length of _bytes_ = _maxLength_, then
-            1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_ }.
+            1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
     </emu-alg>
   </emu-clause>
 
@@ -329,23 +352,27 @@ contributors: Kevin Gibbons
       FromHex (
         _string_: a string,
         optional _maxLength_: a non-negative integer,
-      ): either a normal completion containing a Record with fields [[Read]] (an integral Number) and [[Bytes]] (a List of byte values), or a throw completion
+      ): a Record with fields [[Read]] (an integral Number), [[Bytes]] (a List of byte values), and [[Error]] (either ~none~ or a throw completion)
     </h1>
     <dl class="header">
     </dl>
     <emu-alg>
       1. If _maxLength_ is not present, let _maxLength_ be 2<sup>53</sup> - 1.
       1. Let _length_ be the length of _string_.
-      1. If _length_ modulo 2 is not 0, throw a *SyntaxError* exception.
       1. Let _bytes_ be « ».
-      1. Let _index_ be 0.
-      1. Repeat, while _index_ &lt; _length_ and the length of _bytes_ &lt; _maxLength_,
-        1. Let _hexits_ be the substring of _string_ from _index_ to _index_ + 2.
-        1. If _hexits_ contains any code units which are not in *"0123456789abcdefABCDEF"*, throw a *SyntaxError* exception.
-        1. Set _index_ to _index_ + 2.
+      1. Let _read_ be 0.
+      1. If _length_ modulo 2 is not 0, then
+        1. Let _error_ be a new *SyntaxError* exception.
+        1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
+      1. Repeat, while _read_ &lt; _length_ and the length of _bytes_ &lt; _maxLength_,
+        1. Let _hexits_ be the substring of _string_ from _read_ to _read_ + 2.
+        1. If _hexits_ contains any code units which are not in *"0123456789abcdefABCDEF"*, then
+          1. Let _error_ be a new *SyntaxError* exception.
+          1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
+        1. Set _read_ to _read_ + 2.
         1. Let _byte_ be the integer value represented by _hexits_ in base-16 notation, using the letters A-F and a-f for digits with values 10 through 15.
         1. Append _byte_ to _bytes_.
-      1. Return the Record { [[Read]]: _index_, [[Bytes]]: _bytes_ }.
+      1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
     </emu-alg>
   </emu-clause>
 

--- a/test-polyfill.mjs
+++ b/test-polyfill.mjs
@@ -89,6 +89,14 @@ test('alphabet-specific strings', async t => {
   });
 });
 
+test('valid data before invalid data is written', async t => {
+  let input = 'Zm9vYmFyxx!';
+  let target = new Uint8Array(9);
+
+  assert.throws(() => target.setFromBase64(input), SyntaxError);
+  assert.deepStrictEqual(target, Uint8Array.of(102, 111, 111, 98, 97, 114, 0, 0, 0));
+});
+
 test('writing to an existing buffer', async t => {
   let foobarInput = 'Zm9vYmFy';
   let foobaInput = 'Zm9vYmE';
@@ -215,4 +223,12 @@ test('hex', async t => {
     assert.deepStrictEqual([...output], decoded.slice(0, 3));
     assert.deepStrictEqual({ read, written }, { read: 6, written: 3 });
   });
+});
+
+test('valid data before invalid data is written', async t => {
+  let input = 'deadbeef!!';
+  let target = new Uint8Array(6);
+
+  assert.throws(() => target.setFromHex(input), SyntaxError);
+  assert.deepStrictEqual(target, Uint8Array.of(222, 173, 190, 239, 0, 0));
 });


### PR DESCRIPTION
See https://github.com/tc39/proposal-arraybuffer-base64/issues/57.

One difficulty is that in the case of an error there's no good way to know how many bytes were read/written. I don't think that's a problem we need to solve; in practice you are unlikely to have any way to recover in the case of an error, so you're just going to throw the buffer away.

(It would be nice for SyntaxErrors to have a standardized `.offset` property which told you where the error was, not just for this but also `JSON.parse` etc. But that's unlikely to be in this proposal.)